### PR TITLE
ServiceProvider AdvertisementStatus handling

### DIFF
--- a/test/backends/dotnet/test_serviceprovider.py
+++ b/test/backends/dotnet/test_serviceprovider.py
@@ -1,6 +1,7 @@
 import sys
 import uuid
 import pytest
+import threading
 import aioconsole  # type: ignore
 
 import numpy as np  # type: ignore
@@ -13,26 +14,19 @@ from typing import List  # noqa: E402
 hardware_only = pytest.mark.skipif("os.environ.get('TEST_HARDWARE') is None")
 
 from bleak.backends.dotnet.utils import (  # type: ignore # noqa: E402
-        wrap_IAsyncOperation,
-        BleakDataWriter
-        )
+    wrap_IAsyncOperation,
+    BleakDataWriter,
+)
 
 from bless.backends.characteristic import (  # type: ignore # noqa: E402
-        GattCharacteristicsFlags,
-        GATTAttributePermissions
-        )
-from bless.backends.dotnet.utils import (  # type: ignore # noqa: E402
-        sync_async_wrap
-        )
+    GattCharacteristicsFlags,
+    GATTAttributePermissions,
+)
+from bless.backends.dotnet.utils import sync_async_wrap  # type: ignore # noqa: E402 E501
 
-from Windows.Foundation import (  # type: ignore # noqa: E402
-        IAsyncOperation,
-        Deferral
-        )
+from Windows.Foundation import IAsyncOperation, Deferral  # type: ignore # noqa: E402 E501
 
-from Windows.Storage.Streams import (  # type: ignore # noqa: E40#
-        DataReader, DataWriter
-        )
+from Windows.Storage.Streams import DataReader, DataWriter  # type: ignore # noqa: E402 E501
 
 from Windows.Devices.Bluetooth.GenericAttributeProfile import (  # type: ignore # noqa: E402 F401 E501
     GattWriteOption,
@@ -43,17 +37,15 @@ from Windows.Devices.Bluetooth.GenericAttributeProfile import (  # type: ignore 
     GattLocalCharacteristic,
     GattLocalCharacteristicParameters,
     GattServiceProviderAdvertisingParameters,
+    GattServiceProviderAdvertisementStatusChangedEventArgs,
     GattReadRequestedEventArgs,
     GattReadRequest,
     GattWriteRequestedEventArgs,
     GattWriteRequest,
-    GattSubscribedClient
+    GattSubscribedClient,
 )
 
-from System import (  # type: ignore # noqa: E402
-    Guid,
-    Object
-)
+from System import Guid, Object  # type: ignore # noqa: E402
 
 
 @hardware_only
@@ -61,11 +53,18 @@ class TestServiceProvider:
     """
     Test
     """
+
     hex_words: List[str] = [
-            'DEAD', 'FACE', 'BABE',
-            'CAFE', 'FADE', 'BAD',
-            'DAD', 'ACE', 'BED'
-            ]
+        "DEAD",
+        "FACE",
+        "BABE",
+        "CAFE",
+        "FADE",
+        "BAD",
+        "DAD",
+        "ACE",
+        "BED",
+    ]
 
     val: bytearray = bytearray([0])
 
@@ -74,30 +73,35 @@ class TestServiceProvider:
     @pytest.mark.asyncio
     async def test_init(self):
 
+        start_event: threading.Event = threading.Event()
+
+        def advertisement_status_changed(
+            sender: GattServiceProvider,
+            args: GattServiceProviderAdvertisementStatusChangedEventArgs,
+        ):
+            if args.Status == 2:
+                start_event.set()
+
         def read(
                 sender: GattLocalCharacteristic,
-                args: GattReadRequestedEventArgs
-                ):
+                args: GattReadRequestedEventArgs):
             deferral: Deferral = args.GetDeferral()
             value = self.val
             writer: DataWriter = DataWriter()
             writer.WriteBytes(value)
             request: GattReadRequest = sync_async_wrap(
-                GattReadRequest,
-                args.GetRequestAsync
+                GattReadRequest, args.GetRequestAsync
             )
             request.RespondWithValue(writer.DetachBuffer())
             deferral.Complete()
 
         def write(
                 sender: GattLocalCharacteristic,
-                args: GattWriteRequestedEventArgs
-                ):
+                args: GattWriteRequestedEventArgs):
             deferral: Deferral = args.GetDeferral()
             request: GattWriteRequest = sync_async_wrap(
-                    GattWriteRequest,
-                    args.GetRequestAsync
-                    )
+                GattWriteRequest, args.GetRequestAsync
+            )
             reader: DataReader = DataReader.FromBuffer(request.Value)
             n_bytes: int = reader.UnconsumedBufferLength
             value: bytearray = bytearray()
@@ -111,10 +115,7 @@ class TestServiceProvider:
 
             deferral.Complete()
 
-        def subscribe(
-                sender: GattLocalCharacteristic,
-                args: Object
-                ):
+        def subscribe(sender: GattLocalCharacteristic, args: Object):
             self._subscribed_clients = list(sender.SubscribedClients)
 
         # Create service
@@ -122,13 +123,16 @@ class TestServiceProvider:
         service_guid: Guid = Guid.Parse(service_uuid)
         ServiceProviderResult: GattServiceProviderResult = (
                 await wrap_IAsyncOperation(
-                    IAsyncOperation[GattServiceProviderResult](
-                        GattServiceProvider.CreateAsync(service_guid)),
-                    return_type=GattServiceProviderResult)
-
-                )
+                        IAsyncOperation[GattServiceProviderResult](
+                                GattServiceProvider.CreateAsync(service_guid)
+                                ),
+                        return_type=GattServiceProviderResult)
+                        )
         service_provider: GattServiceProvider = (
                 ServiceProviderResult.ServiceProvider
+                )
+        service_provider.AdvertisementStatusChanged += (
+                advertisement_status_changed
                 )
 
         new_service: GattLocalService = service_provider.Service
@@ -138,32 +142,31 @@ class TestServiceProvider:
         char_guid: Guid = Guid.Parse(char_uuid)
 
         properties: GattCharacteristicsFlags = (
-                GattCharacteristicsFlags.read |
-                GattCharacteristicsFlags.write |
-                GattCharacteristicsFlags.notify
-                )
+            GattCharacteristicsFlags.read
+            | GattCharacteristicsFlags.write
+            | GattCharacteristicsFlags.notify
+        )
 
         permissions: GATTAttributePermissions = (
-                GATTAttributePermissions.readable |
-                GATTAttributePermissions.writeable
-                )
+            GATTAttributePermissions.readable |
+            GATTAttributePermissions.writeable
+        )
 
         ReadParameters: GattLocalCharacteristicParameters = (
-                GattLocalCharacteristicParameters()
-                )
+            GattLocalCharacteristicParameters()
+        )
         ReadParameters.CharacteristicProperties = properties.value
         ReadParameters.ReadProtectionLevel = permissions.value
 
         characteristic_result: GattLocalCharacteristicResult = (
-                await wrap_IAsyncOperation(
-                    IAsyncOperation[GattLocalCharacteristicResult](
-                        new_service.CreateCharacteristicAsync(
-                            char_guid,
-                            ReadParameters
-                            )
-                        ),
-                    return_type=GattLocalCharacteristicResult)
-                )
+            await wrap_IAsyncOperation(
+                IAsyncOperation[GattLocalCharacteristicResult](
+                    new_service.CreateCharacteristicAsync(
+                        char_guid, ReadParameters)
+                ),
+                return_type=GattLocalCharacteristicResult,
+            )
+        )
         newChar: GattLocalCharacteristic = characteristic_result.Characteristic
         newChar.ReadRequested += read
         newChar.WriteRequested += write
@@ -174,65 +177,61 @@ class TestServiceProvider:
 
         # Advertise
         adv_parameters: GattServiceProviderAdvertisingParameters = (
-                GattServiceProviderAdvertisingParameters()
-                )
+            GattServiceProviderAdvertisingParameters()
+        )
         adv_parameters.IsDiscoverable = True
         adv_parameters.IsConnectable = True
 
         service_provider.StartAdvertising(adv_parameters)
 
         # Check
+        start_event.wait()
         assert service_provider.AdvertisementStatus == 2
 
         # We shouldn't be connected
         assert len(self._subscribed_clients) < 1
 
         print(
-                "\nPlease connect now" +
-                "and subscribe to the characteristic {}..."
-                .format(char_uuid)
-                )
+            "\nPlease connect now"
+            + "and subscribe to the characteristic {}...".format(char_uuid)
+        )
         await aioconsole.ainput("Press enter when ready...")
 
         assert len(self._subscribed_clients) > 0
 
         # Read test
         rng: np.random._generator.Generator = np.random.default_rng()
-        hex_val: str = ''.join(rng.choice(self.hex_words, 2, replace=False))
+        hex_val: str = "".join(rng.choice(self.hex_words, 2, replace=False))
         self.val = bytearray(
-                int(f"0x{hex_val}", 16).to_bytes(
-                    length=int(np.ceil(len(hex_val)/2)),
-                    byteorder='big'
-                    )
-                )
+            int(f"0x{hex_val}", 16).to_bytes(
+                length=int(np.ceil(len(hex_val) / 2)), byteorder="big"
+            )
+        )
 
         print("Trigger a read and enter the hex value you see below")
         entered_value = await aioconsole.ainput("Value: ")
         assert entered_value == hex_val
 
         # Write test
-        hex_val = ''.join(rng.choice(self.hex_words, 2, replace=False))
+        hex_val = "".join(rng.choice(self.hex_words, 2, replace=False))
         print(f"Set the characteristic to the following: {hex_val}")
         await aioconsole.ainput("Press enter when ready...")
-        str_val: str = ''.join([hex(x)[2:] for x in self.val]).upper()
+        str_val: str = "".join([hex(x)[2:] for x in self.val]).upper()
         assert str_val == hex_val
 
         # Notify test
-        hex_val = ''.join(rng.choice(self.hex_words, 2, replace=False))
+        hex_val = "".join(rng.choice(self.hex_words, 2, replace=False))
         self.val = bytearray(
-                int(f"0x{hex_val}", 16).to_bytes(
-                    length=int(np.ceil(len(hex_val)/2)),
-                    byteorder='big'
-                    )
-                )
+            int(f"0x{hex_val}", 16).to_bytes(
+                length=int(np.ceil(len(hex_val) / 2)), byteorder="big"
+            )
+        )
 
         print("A new value will be sent")
         await aioconsole.ainput("Press enter to receive the new value...")
 
         with BleakDataWriter(self.val) as writer:
-            newChar.NotifyValueAsync(
-                    writer.detach_buffer()
-                    )
+            newChar.NotifyValueAsync(writer.detach_buffer())
 
         new_value: str = await aioconsole.ainput("Enter the New value: ")
         assert new_value == hex_val
@@ -244,4 +243,7 @@ class TestServiceProvider:
 
         # Stop Advertising
         service_provider.StopAdvertising()
-        assert service_provider.AdvertisementStatus != 2
+
+        # There are some cases where calls to `StopAdvertising` does not update
+        # the `AdvertisementStatus`
+        # assert service_provider.AdvertisementStatus != 2


### PR DESCRIPTION
On some windows systems calls to `GattServiceProvider.StartAdvertising()` results in a abort status (3) followed by a success (2). These changes handle these resets by waiting for the success message. Additionally, calling `StopAdvertising()` fails to update the status. This resolves #13 