### PR TITLE
Characteristic attributes

### DIFF
--- a/bless/__init__.py
+++ b/bless/__init__.py
@@ -44,7 +44,7 @@ elif sys.platform == "win32":
 
 # type: ignore
 from bless.backends.characteristic import (  # noqa: E402 F401
-    GattCharacteristicsFlags,
+    GATTCharacteristicProperties,
     GATTAttributePermissions,
 )
 

--- a/bless/backends/bluezdbus/characteristic.py
+++ b/bless/backends/bluezdbus/characteristic.py
@@ -10,7 +10,7 @@ from txdbus.interface import DBusInterface, Method, Property  # type: ignore
 from bleak.backends.bluezdbus.characteristic import (  # type: ignore
     _GattCharacteristicsFlagsEnum,
 )
-from bless.backends.characteristic import GattCharacteristicsFlags  # type: ignore
+from bless.backends.characteristic import GATTCharacteristicProperties  # type: ignore
 
 if TYPE_CHECKING:
     from bless.backends.bluezdbus.service import (  # type: ignore
@@ -35,13 +35,13 @@ class Flags(Enum):
     ENCRYPT_AUTHENTICATED_WRITE = "encrypt-authenticated-write"
 
     @classmethod
-    def from_bless(cls, flags: GattCharacteristicsFlags) -> List["Flags"]:
+    def from_bless(cls, flags: GATTCharacteristicProperties) -> List["Flags"]:
         """
         Convert Bleak/Bless flags
 
         Parameters
         ----------
-        flags : GattCharacteristicFlags
+        flags : GATTCharacteristicProperties
             The numerical enumeration for the combined flags
 
         Returns
@@ -50,9 +50,7 @@ class Flags(Enum):
             A list fo Flags for use in BlueZDBus
         """
         result: List[Flags] = []
-        # Apparently, the tests and examples are passing in integers, these
-        # should be th Gatt Flags
-        flag_value: GattCharacteristicsFlags = flags
+        flag_value: int = flags.value
         for i, int_flag in enumerate(_GattCharacteristicsFlagsEnum.keys()):
             included: bool = int_flag & flag_value > 0
             if included:

--- a/bless/backends/bluezdbus/server.py
+++ b/bless/backends/bluezdbus/server.py
@@ -23,7 +23,7 @@ from bless.backends.bluezdbus.characteristic import (  # type: ignore
     Flags,
 )
 
-from bless.backends.characteristic import GattCharacteristicsFlags  # type: ignore
+from bless.backends.characteristic import GATTCharacteristicProperties  # type: ignore
 
 
 class BlessServerBlueZDBus(BaseBlessServer):
@@ -159,7 +159,7 @@ class BlessServerBlueZDBus(BaseBlessServer):
         self,
         service_uuid: str,
         char_uuid: str,
-        properties: GattCharacteristicsFlags,
+        properties: GATTCharacteristicProperties,
         value: Optional[bytearray],
         permissions: int,
     ):
@@ -173,7 +173,7 @@ class BlessServerBlueZDBus(BaseBlessServer):
             this new characteristic should belong
         char_uuid : str
             The string representation of the UUID of the characteristic
-        properties : GattCharacteristicsFlags
+        properties : GATTCharacteristicProperties
             GATT Characteristic Flags that define the characteristic
         value : Optional[bytearray]
             A byterray representation of the value to be associated with the

--- a/bless/backends/bluezdbus/server.py
+++ b/bless/backends/bluezdbus/server.py
@@ -23,7 +23,10 @@ from bless.backends.bluezdbus.characteristic import (  # type: ignore
     Flags,
 )
 
-from bless.backends.characteristic import GATTCharacteristicProperties  # type: ignore
+from bless.backends.characteristic import (  # type: ignore
+        GATTCharacteristicProperties,
+        GATTAttributePermissions
+        )
 
 
 class BlessServerBlueZDBus(BaseBlessServer):
@@ -161,7 +164,7 @@ class BlessServerBlueZDBus(BaseBlessServer):
         char_uuid: str,
         properties: GATTCharacteristicProperties,
         value: Optional[bytearray],
-        permissions: int,
+        permissions: GATTAttributePermissions,
     ):
         """
         Add a new characteristic to be associated with the server

--- a/bless/backends/characteristic.py
+++ b/bless/backends/characteristic.py
@@ -5,7 +5,7 @@ from enum import Flag
 from bleak.backends.characteristic import BleakGATTCharacteristic  # type: ignore
 
 
-class GattCharacteristicsFlags(Flag):
+class GATTCharacteristicProperties(Flag):
     broadcast = 0x0001
     read = 0x0002
     write_without_response = 0x0004

--- a/bless/backends/corebluetooth/server.py
+++ b/bless/backends/corebluetooth/server.py
@@ -22,7 +22,10 @@ from bless.backends.corebluetooth.service import BlessGATTServiceCoreBluetooth
 from bless.backends.corebluetooth.characteristic import (  # type: ignore
     BlessGATTCharacteristicCoreBluetooth,
 )
-from bless.backends.characteristic import GattCharacteristicsFlags  # type: ignore
+from bless.backends.characteristic import (
+        GATTCharacteristicProperties,
+        GATTAttributePermissions
+        )
 
 
 logger = logging.getLogger(name=__name__)
@@ -149,9 +152,9 @@ class BlessServerCoreBluetooth(BaseBlessServer):
         self,
         service_uuid: str,
         char_uuid: str,
-        properties: GattCharacteristicsFlags,
+        properties: GATTCharacteristicProperties,
         value: Optional[bytearray],
-        permissions: int,
+        permissions: GATTAttributePermissions,
     ):
         """
         Generate a new characteristic to be associated with the server
@@ -164,18 +167,20 @@ class BlessServerCoreBluetooth(BaseBlessServer):
         char_uuid : str
             The string representation of the UUID for the characteristic to be
             added
-        properties : GattCharacteristicsFlags
+        properties : GATTCharacteristicProperties
             The flags for the characteristic
         value : Optional[bytearray]
             The initial value for the characteristic
-        permissions : int
+        permissions : GATTAttributePermissions
             The permissions for the characteristic
         """
         logger.debug("Craeting a new characteristic with uuid: {}".format(char_uuid))
+        properties_value: int = properties.value
+        permissions_value: int = permissions.value
         cb_uuid: CBUUID = CBUUID.alloc().initWithString_(char_uuid)
         cb_characteristic: CBMutableCharacteristic = (
             CBMutableCharacteristic.alloc().initWithType_properties_value_permissions_(
-                cb_uuid, properties, value, permissions
+                cb_uuid, properties_value, value, permissions_value
             )
         )
         bless_characteristic: BlessGATTCharacteristicCoreBluetooth = (

--- a/bless/backends/dotnet/server.py
+++ b/bless/backends/dotnet/server.py
@@ -11,7 +11,7 @@ from bleak.backends.dotnet.utils import (  # type: ignore
 
 from bless.exceptions import BlessError
 from bless.backends.server import BaseBlessServer  # type: ignore
-from bless.backends.characteristic import GattCharacteristicsFlags  # type: ignore
+from bless.backends.characteristic import GATTCharacteristicProperties  # type: ignore
 from bless.backends.dotnet.service import BlessGATTServiceDotNet
 from bless.backends.dotnet.characteristic import (  # type: ignore
     BlessGATTCharacteristicDotNet,
@@ -189,7 +189,7 @@ class BlessServerDotNet(BaseBlessServer):
         self,
         service_uuid: str,
         char_uuid: str,
-        properties: GattCharacteristicsFlags,
+        properties: GATTCharacteristicProperties,
         value: Optional[bytearray],
         permissions: int,
     ):
@@ -203,7 +203,7 @@ class BlessServerDotNet(BaseBlessServer):
             the new characteristic with
         char_uuid : str
             The string representation of the uuid of the new characteristic
-        properties : GattCharacteristicsFlags
+        properties : GATTCharacteristicProperties
             The flags for the characteristic
         value : Optional[bytearray]
             The initial value for the characteristic
@@ -216,8 +216,8 @@ class BlessServerDotNet(BaseBlessServer):
         ReadParameters: GattLocalCharacteristicParameters = (
             GattLocalCharacteristicParameters()
         )
-        ReadParameters.CharacteristicProperties = properties
-        ReadParameters.ReadProtectionLevel = permissions
+        ReadParameters.CharacteristicProperties = properties.value
+        ReadParameters.ReadProtectionLevel = permissions.value
 
         service: GattLocalService = self.services[str(serverguid)]
         characteristic_result: GattLocalCharacteristicResult = (

--- a/bless/backends/dotnet/server.py
+++ b/bless/backends/dotnet/server.py
@@ -11,7 +11,10 @@ from bleak.backends.dotnet.utils import (  # type: ignore
 
 from bless.exceptions import BlessError
 from bless.backends.server import BaseBlessServer  # type: ignore
-from bless.backends.characteristic import GATTCharacteristicProperties  # type: ignore
+from bless.backends.characteristic import (  # type: ignore
+        GATTCharacteristicProperties,
+        GATTAttributePermissions
+        )
 from bless.backends.dotnet.service import BlessGATTServiceDotNet
 from bless.backends.dotnet.characteristic import (  # type: ignore
     BlessGATTCharacteristicDotNet,
@@ -191,7 +194,7 @@ class BlessServerDotNet(BaseBlessServer):
         char_uuid: str,
         properties: GATTCharacteristicProperties,
         value: Optional[bytearray],
-        permissions: int,
+        permissions: GATTAttributePermissions,
     ):
         """
         Generate a new characteristic to be associated with the server

--- a/bless/backends/server.py
+++ b/bless/backends/server.py
@@ -9,7 +9,8 @@ from bleak.backends.service import BleakGATTService  # type: ignore
 
 from bless.backends.characteristic import (  # type: ignore
     BlessGATTCharacteristic,
-    GattCharacteristicsFlags,
+    GATTCharacteristicProperties,
+    GATTAttributePermissions
 )
 
 from bless.exceptions import BlessError
@@ -110,9 +111,9 @@ class BaseBlessServer(abc.ABC):
         self,
         service_uuid: str,
         char_uuid: str,
-        properties: GattCharacteristicsFlags,
+        properties: GATTCharacteristicProperties,
         value: Optional[bytearray],
-        permissions: int,
+        permissions: GATTAttributePermissions,
     ):
         """
         Add a new characteristic to be associated with the server
@@ -124,14 +125,13 @@ class BaseBlessServer(abc.ABC):
             this new characteristic should belong
         char_uuid : str
             The string representation of the UUID of the characteristic
-        properties : GattCharacteristicsFlags
+        properties : GATTCharacteristicProperties
             GATT Characteristic Flags that define the characteristic
         value : Optional[bytearray]
             A byterray representation of the value to be associated with the
             characteristic. Can be None if the characteristic is writable
-        permissions : int
-            GATT Characteristic flags that define the permissions for the
-            characteristic
+        permissions : GATTAttributePermissions
+            GATT flags that define the permissions for the characteristic
         """
         raise NotImplementedError()
 

--- a/test/backends/corebluetooth/test_peripheralmanagerdelegate.py
+++ b/test/backends/corebluetooth/test_peripheralmanagerdelegate.py
@@ -18,7 +18,7 @@ from CoreBluetooth import (  # type: ignore # noqa: E402
         )
 
 from bless.backends.characteristic import (  # type: ignore # noqa: E402
-        GattCharacteristicsFlags
+        GATTCharacteristicProperties
         )
 
 from bless.backends.corebluetooth.PeripheralManagerDelegate import (  # type: ignore # noqa: E402 E501
@@ -87,10 +87,10 @@ class TestPeripheralManagerDelegate:
                     )
 
             # Add a subscribable Characteristic
-            props: GattCharacteristicsFlags = (
-                    GattCharacteristicsFlags.read |
-                    GattCharacteristicsFlags.write |
-                    GattCharacteristicsFlags.notify
+            props: GATTCharacteristicProperties = (
+                    GATTCharacteristicProperties.read |
+                    GATTCharacteristicProperties.write |
+                    GATTCharacteristicProperties.notify
                     )
             permissions: CBAttributePermissions = (
                     CBAttributePermissions.readable |

--- a/test/backends/dotnet/test_serviceprovider.py
+++ b/test/backends/dotnet/test_serviceprovider.py
@@ -19,7 +19,7 @@ from bleak.backends.dotnet.utils import (  # type: ignore # noqa: E402
 )
 
 from bless.backends.characteristic import (  # type: ignore # noqa: E402
-    GattCharacteristicsFlags,
+    GATTCharacteristicProperties,
     GATTAttributePermissions,
 )
 from bless.backends.dotnet.utils import sync_async_wrap  # type: ignore # noqa: E402 E501
@@ -141,10 +141,10 @@ class TestServiceProvider:
         char_uuid: str = str(uuid.uuid4())
         char_guid: Guid = Guid.Parse(char_uuid)
 
-        properties: GattCharacteristicsFlags = (
-            GattCharacteristicsFlags.read
-            | GattCharacteristicsFlags.write
-            | GattCharacteristicsFlags.notify
+        properties: GATTCharacteristicProperties = (
+            GATTCharacteristicProperties.read
+            | GATTCharacteristicProperties.write
+            | GATTCharacteristicProperties.notify
         )
 
         permissions: GATTAttributePermissions = (

--- a/test/backends/test_server.py
+++ b/test/backends/test_server.py
@@ -21,7 +21,7 @@ if sys.platform not in ['darwin', 'linux', 'win32']:
 
 from bless import BlessServer  # type: ignore  # noqa: E402
 from bless.backends.characteristic import (  # noqa: E402
-        GattCharacteristicsFlags,
+        GATTCharacteristicProperties,
         GATTAttributePermissions
         )
 
@@ -73,10 +73,10 @@ class TestBlessServer:
 
         # setup a characteristic for the service
         char_uuid: str = str(uuid.uuid4())
-        char_flags: GattCharacteristicsFlags = (
-                GattCharacteristicsFlags.read |
-                GattCharacteristicsFlags.write |
-                GattCharacteristicsFlags.notify
+        char_flags: GATTCharacteristicProperties = (
+                GATTCharacteristicProperties.read |
+                GATTCharacteristicProperties.write |
+                GATTCharacteristicProperties.notify
                 )
         value: Optional[bytearray] = None
         permissions: GATTAttributePermissions = (
@@ -87,9 +87,9 @@ class TestBlessServer:
         await server.add_new_characteristic(
                 service_uuid,
                 char_uuid,
-                char_flags.value,
+                char_flags,
                 value,
-                permissions.value
+                permissions
                 )
 
         assert server.services[service_uuid].get_characteristic(char_uuid)
@@ -99,7 +99,7 @@ class TestBlessServer:
             return characteristic.value
 
         def write(characteristic: BlessGATTCharacteristic, value: bytearray):
-            characteristic.value = value
+            characteristic.value = value  # type: ignore
 
         server.read_request_func = read
         server.write_request_func = write


### PR DESCRIPTION
This request changes `GattAttributePermissions` to `GATTAttributePermissions` for naming consistancy and removes the need to pass the integer value of the enumeration objects when adding new characteristics.

Closes #31