### PR TITLE
Characteristic protection level

### DIFF
--- a/bless/backends/dotnet/characteristic.py
+++ b/bless/backends/dotnet/characteristic.py
@@ -1,12 +1,13 @@
-from enum import Flag
-
 from bleak.backends.dotnet.characteristic import (  # type: ignore
     BleakGATTCharacteristicDotNet,
 )
 
-from Windows.Devices.Bluetooth.GenericAttributeProfile import GattProtectionLevel
+from Windows.Devices.Bluetooth.GenericAttributeProfile import (  # type: ignore
+    GattProtectionLevel
+)
 
 from bless.backends.characteristic import GATTAttributePermissions
+
 
 class BlessGATTCharacteristicDotNet(BleakGATTCharacteristicDotNet):
     """
@@ -18,7 +19,9 @@ class BlessGATTCharacteristicDotNet(BleakGATTCharacteristicDotNet):
         self._value: bytearray = bytearray(b"")
 
     @staticmethod
-    def permissions_to_protection_level(permissions: GATTAttributePermissions, read: bool) -> GattProtectionLevel:
+    def permissions_to_protection_level(
+        permissions: GATTAttributePermissions, read: bool
+    ) -> GattProtectionLevel:
         """
         Convert the GATTAttributePermissions into a GattProtectionLevel
         GATTAttributePermissions currently only consider Encryption or Plain
@@ -29,7 +32,7 @@ class BlessGATTCharacteristicDotNet(BleakGATTCharacteristicDotNet):
             The permission flags for the characteristic
         read : bool
             If True, processes the permissions for Reading, else process for Writing
-        
+
         Returns
         -------
         GattProtectionLevel
@@ -41,7 +44,6 @@ class BlessGATTCharacteristicDotNet(BleakGATTCharacteristicDotNet):
         if permission_value & 1:
             result |= GattProtectionLevel.EncryptionRequired
         return result
-
 
     @property
     def value(self) -> bytearray:

--- a/bless/backends/dotnet/server.py
+++ b/bless/backends/dotnet/server.py
@@ -12,9 +12,9 @@ from bleak.backends.dotnet.utils import (  # type: ignore
 from bless.exceptions import BlessError
 from bless.backends.server import BaseBlessServer  # type: ignore
 from bless.backends.characteristic import (  # type: ignore
-        GATTCharacteristicProperties,
-        GATTAttributePermissions
-        )
+    GATTCharacteristicProperties,
+    GATTAttributePermissions,
+)
 from bless.backends.dotnet.service import BlessGATTServiceDotNet
 from bless.backends.dotnet.characteristic import (  # type: ignore
     BlessGATTCharacteristicDotNet,
@@ -220,7 +220,16 @@ class BlessServerDotNet(BaseBlessServer):
             GattLocalCharacteristicParameters()
         )
         ReadParameters.CharacteristicProperties = properties.value
-        ReadParameters.ReadProtectionLevel = permissions.value
+        ReadParameters.ReadProtectionLevel = (
+            BlessGATTCharacteristicDotNet.permissions_to_protection_level(
+                permissions, True
+            )
+        )
+        ReadParameters.WriteProtectionLevel = (
+            BlessGATTCharacteristicDotNet.permissions_to_protection_level(
+                permissions, False
+            )
+        )
 
         service: GattLocalService = self.services[str(serverguid)]
         characteristic_result: GattLocalCharacteristicResult = (


### PR DESCRIPTION
Closes #35 

Ensures that the underlying DotNet GattLocalCharacteristic is initialized with the appropriate protection level based on the GATTAttributePermissions