### PR TITLE
Add linux dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,9 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=("test", "examples")),
     include_package_data=True,
     install_requires=[
-        "bleak"
+        "bleak",
+        "twisted; platform_system == 'Linux' ",
+        "txdbus; platform_system == 'Linux'"
         ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
txdbus and twister were previously installed together with bleak.
However, bleak has since moved to using dbus-next. May be better to
switch to if we see a need.