### PR TITLE
FTMS_gatt_server as an example

### DIFF
--- a/examples/FTMSclient.py
+++ b/examples/FTMSclient.py
@@ -51,7 +51,8 @@
 #-------------------------------------------------------------------------------
 # Version info
 #-------------------------------------------------------------------------------
-__version__ = "2022-03-14"
+__version__ = "2022-03-21"
+# 2022-03-21    Made available to kevincar/bless as example; small modifications
 # 2022-03-16    bleBleak.py works on Windows 10
 #               - sometimes the BLE dongle must be reset (remove/insert)
 #               - sometimes indications are not received
@@ -87,8 +88,8 @@ from bleak import __version__ as bleakVersion
 
 import struct
 
-BlessExample = True
-if not BlessExample:
+if False:
+    BlessExample = False
     #---------------------------------------------------------------------------
     # Import in the FortiusAnt context
     #---------------------------------------------------------------------------
@@ -97,18 +98,16 @@ if not BlessExample:
     from   bleBlessClass        import clsBleServer
     import bleConstants         as bc
 
-if BlessExample:
+else:
+    BlessExample = True
     #---------------------------------------------------------------------------
     # Import and Constants for bless example context
     #---------------------------------------------------------------------------
     import FTMSconstants        as bc
-
-    def HexSpace(info):
-        return (info)
-
+    from   FTMSconstants        import HexSpace
 
 #-------------------------------------------------------------------------------
-# Status feb 2022:
+# Status mar 2022:
 #-------------------------------------------------------------------------------
 # Notes on Windows 10 Pro, version 21H2, build 19044.1526
 #                          Windows Feature Experience Pack 120.2212.4170.0
@@ -118,14 +117,12 @@ if BlessExample:
 #
 # When indications are not received, the simulation loop does not work
 #-------------------------------------------------------------------------------
-# Raspberry rpi0W with Raspbian version (10) buster
-# - bleBleak.py works; sample output added to end-of-this-file.
+# Tested on:
+# 1. Raspberry rpi0W with Raspbian version (10) buster
+# 2. Windows 10 (for version see above)
+# --> bleBleak.py works; sample output added to end-of-this-file.
 #-------------------------------------------------------------------------------
 print("bleak = %s" % bleakVersion)
-if os.name == 'nt':
-    print("************************************************************************")
-    print("***** bleBleak.py works under Windows 10; but is not always stable *****")
-    print("************************************************************************\n\n")
 
 #-------------------------------------------------------------------------------
 # ADDRESSES: Returned by findBLEdevices()
@@ -321,7 +318,25 @@ async def serverInspectionSub(client):
                 else:
                     s = HexSpace(value)
 
-                s = '\tCharacteristic: %-80s, props=%s, value=%s' % (char, char.properties, s)
+                #---------------------------------------------------------------
+                # Get description, if known in our context
+                #---------------------------------------------------------------
+                uuid  = str(char.uuid)
+                if   uuid == bc.cDeviceNameUUID:                 descr = bc.cDeviceNameName
+                elif uuid == bc.cAppearanceUUID:                 descr = bc.cAppearanceName
+
+                elif uuid == bc.cFitnessMachineFeatureUUID:      descr = bc.cFitnessMachineFeatureName
+                elif uuid == bc.cIndoorBikeDataUUID:             descr = bc.cIndoorBikeDataName
+                elif uuid == bc.cFitnessMachineStatusUUID:       descr = bc.cFitnessMachineStatusName
+                elif uuid == bc.cFitnessMachineControlPointUUID: descr = bc.cFitnessMachineControlPointName
+                elif uuid == bc.cSupportedPowerRangeUUID:        descr = bc.cSupportedPowerRangeName
+                elif uuid == bc.cHeartRateMeasurementUUID:       descr = bc.cHeartRateMeasurementUUID
+                else:                                            descr = "?"
+
+                #---------------------------------------------------------------
+                # And print
+                #---------------------------------------------------------------
+                s = '\tCharacteristic: uuid=%-12s (handle: %3s): %-30s, props=%s, value=%s' % (char.uuid, char.handle, descr, char.properties, s)
                 s = s.replace(bc.BluetoothBaseUUIDsuffix, '-...') # Always the same
                 print(s)
 
@@ -680,60 +695,89 @@ SAMPLE OUTPUT:
 ==============
 
 -------------------------------
- Discover existing BLE devices 
+ Discover existing BLE devices
 -------------------------------
-75:A1:76:76:46:49: 75-A1-76-76-46-49
-5C:F3:70:9F:8C:98: FortiusANT Trainer
-24:B7:A7:30:5A:01: 24-B7-A7-30-5A-01
+No devices found, retry
+B8:27:EB:0B:EA:62: Unknown will be inspected
 ---------------------------------------------------
- Inspect BLE-device with address 5C:F3:70:9F:8C:98
+ Inspect BLE-device with address B8:27:EB:0B:EA:62
 ---------------------------------------------------
 Connected:  True
-<Unknown>: This is a matching Fitness Machine
-Service: 0000180d-... (Handle: 29): Heart Rate
-	Characteristic: 00002a37-... (Handle: 30): Heart Rate Measurement       , props=['notify'], value="(N/A: Wait for notification)"
-Service: 00001826-... (Handle: 10): Fitness Machine
-	Characteristic: 00002ad8-... (Handle: 26): Supported Power Range        , props=['read'], value="00 00 e8 03 01 00"
-	Characteristic: 00002ad9-... (Handle: 22): Fitness Machine Control Point, props=['write', 'indicate'], value="(N/A: Wait for indication)"
-	Characteristic: 00002ada-... (Handle: 18): Fitness Machine Status       , props=['notify'], value="(N/A: Wait for notification)"
-	Characteristic: 00002ad2-... (Handle: 14): Indoor Bike Data             , props=['notify'], value="(N/A: Wait for notification)"
-	Characteristic: 00002acc-... (Handle: 11): Fitness Machine Feature      , props=['read'], value="02 40 00 00 08 20 00 00"
-		Supported: Cadence, PowerMeasurement, PowerTargetSetting, IndoorBikeSimulation.
+Device Name=rpiServer
+Appearance=bytearray(b'\x00\x00')
+rpiServer: This is a matching Fitness Machine
+Service: 00001800-... (Handle: 1): Generic Access Profile
+        Characteristic: uuid=00002a00-... (handle:   2): Device Name                   , props=['read'], value="rpiServer"
+        Characteristic: uuid=00002a01-... (handle:   4): Appearance                    , props=['read'], value="00 00"
 Service: 00001801-... (Handle: 6): Generic Attribute Profile
-	Characteristic: 00002a05-... (Handle: 7): Service Changed               , props=['indicate'], value="(N/A; not readable)"
+        Characteristic: uuid=00002a05-... (handle:   7): ?                             , props=['indicate'], value="(N/A; not readable)"
+Service: 00001826-... (Handle: 331): Fitness Machine
+        Characteristic: uuid=00002acc-... (handle: 332): Fitness Machine Feature       , props=['read'], value="02 40 00 00 08 20 00 00"
+                Supported: Cadence, PowerMeasurement, PowerTargetSetting, IndoorBikeSimulation.
+        Characteristic: uuid=00002ad2-... (handle: 334): Indoor Bike Data              , props=['notify'], value="(N/A: Wait for notification)"
+        Characteristic: uuid=00002ada-... (handle: 337): Fitness Machine Status        , props=['notify'], value="(N/A: Wait for notification)"
+        Characteristic: uuid=00002ad9-... (handle: 340): Fitness Machine Control Point , props=['write', 'indicate'], value="(N/A: Wait for indication)"
+        Characteristic: uuid=00002ad8-... (handle: 343): Supported Power Range         , props=['read'], value="00 00 e8 03 01 00"
 Register notifications
-14 Indoor Bike Data       "44 00 00 00 c4 00 31 00" status=initial    speed=0 cadence= 98 power=  49 hrm=  0
-30 Heart Rate Measurement "00 5f"                   status=initial    speed=0 cadence= 98 power=  49 hrm= 95
+Registration failed Characteristic 00002a37-0000-1000-8000-00805f9b34fb not found!
 Register indications
 ------------------------------------------------------
- Start simulation of a Cycling Training Program (CTP) 
+ Start simulation of a Cycling Training Program (CTP)
 ------------------------------------------------------
 Request control, so that commands can be sent
-14 Indoor Bike Data       "44 00 00 00 c6 00 31 00" status=initial    speed=0 cadence= 99 power=  49 hrm= 95
-30 Heart Rate Measurement "00 57"                   status=initial    speed=0 cadence= 99 power=  49 hrm= 87
-...
+340 Fitness Machine Control Point "80 00 01" ResponseCode=128 RequestCode=0 ResultCode=1(Succes)
+334 Indoor Bike Data       "44 00 fc 53 e6 00 3b 01" status=initial    speed=215.0 cadence=115 power= 315 hrm=  0
 Start training session
-18 Fitness Machine Status "04"                      status=Started    speed=0 cadence=100 power=  51 hrm= 85
-...
+337 Fitness Machine Status "04"                      status=Started    speed=215.0 cadence=115 power= 315 hrm=  0
+340 Fitness Machine Control Point "80 07 01" ResponseCode=128 RequestCode=7 ResultCode=1(Succes)
+334 Indoor Bike Data       "44 00 60 54 e8 00 3c 01" status=Started    speed=216.0 cadence=116 power= 316 hrm=  0
 Switch to PowerMode, 324W
-14 Indoor Bike Data       "44 00 00 00 ca 00 31 00" status=Started    speed=0 cadence=101 power=  49 hrm= 85
-...
+337 Fitness Machine Status "08 44 01"                status=Power mode speed=216.0 cadence=116 power= 316 hrm=  0
+340 Fitness Machine Control Point "80 05 01" ResponseCode=128 RequestCode=5 ResultCode=1(Succes)
+334 Indoor Bike Data       "44 00 c4 54 ea 00 3d 01" status=Power mode speed=217.0 cadence=117 power= 317 hrm=  0
 Switch to GradeMode, 4%
-18 Fitness Machine Status "12 00 00 04 00 00 00"    status=Grade mode speed=0 cadence= 97 power= 145 hrm=105
-...
+337 Fitness Machine Status "12 00 00 90 01 28 33"    status=Grade mode speed=217.0 cadence=117 power= 317 hrm=  0
+340 Fitness Machine Control Point "80 11 01" ResponseCode=128 RequestCode=17 ResultCode=1(Succes)
+334 Indoor Bike Data       "44 00 28 55 ec 00 3e 01" status=Grade mode speed=218.0 cadence=118 power= 318 hrm=  0
+Switch to PowerMode, 323W
+337 Fitness Machine Status "08 43 01"                status=Power mode speed=218.0 cadence=118 power= 318 hrm=  0
+340 Fitness Machine Control Point "80 05 01" ResponseCode=128 RequestCode=5 ResultCode=1(Succes)
+334 Indoor Bike Data       "44 00 8c 55 ee 00 3f 01" status=Power mode speed=219.0 cadence=119 power= 319 hrm=  0
+Switch to GradeMode, 3%
+340 Fitness Machine Control Point "80 11 01" ResponseCode=128 RequestCode=17 ResultCode=1(Succes)
+337 Fitness Machine Status "12 00 00 2c 01 28 33"    status=Grade mode speed=219.0 cadence=119 power= 319 hrm=  0
+334 Indoor Bike Data       "44 00 f0 55 f0 00 40 01" status=Grade mode speed=220.0 cadence=120 power= 320 hrm=  0
+Switch to PowerMode, 322W
+337 Fitness Machine Status "08 42 01"                status=Power mode speed=220.0 cadence=120 power= 320 hrm=  0
+340 Fitness Machine Control Point "80 05 01" ResponseCode=128 RequestCode=5 ResultCode=1(Succes)
+334 Indoor Bike Data       "44 00 54 56 f2 00 41 01" status=Power mode speed=221.0 cadence=121 power= 321 hrm=  0
+Switch to GradeMode, 2%
+337 Fitness Machine Status "12 00 00 c8 00 28 33"    status=Grade mode speed=221.0 cadence=121 power= 321 hrm=  0
+340 Fitness Machine Control Point "80 11 01" ResponseCode=128 RequestCode=17 ResultCode=1(Succes)
+334 Indoor Bike Data       "44 00 b8 56 f4 00 42 01" status=Grade mode speed=222.0 cadence=122 power= 322 hrm=  0
+Switch to PowerMode, 321W
+334 Indoor Bike Data       "44 00 1c 57 f6 00 43 01" status=Grade mode speed=223.0 cadence=123 power= 323 hrm=  0
+337 Fitness Machine Status "08 41 01"                status=Power mode speed=223.0 cadence=123 power= 323 hrm=  0
+340 Fitness Machine Control Point "80 05 01" ResponseCode=128 RequestCode=5 ResultCode=1(Succes)
+334 Indoor Bike Data       "44 00 80 57 f8 00 44 01" status=Power mode speed=224.0 cadence=124 power= 324 hrm=  0
+Switch to GradeMode, 1%
+337 Fitness Machine Status "12 00 00 64 00 28 33"    status=Grade mode speed=224.0 cadence=124 power= 324 hrm=  0
+340 Fitness Machine Control Point "80 11 01" ResponseCode=128 RequestCode=17 ResultCode=1(Succes)
+334 Indoor Bike Data       "44 00 e4 57 fa 00 45 01" status=Grade mode speed=225.0 cadence=125 power= 325 hrm=  0
 Switch to PowerMode, 50W
-18 Fitness Machine Status "08 32 00"                status=Power mode speed=0 cadence=101 power= 340 hrm=184
-...
+337 Fitness Machine Status "08 32 00"                status=Power mode speed=225.0 cadence=125 power= 325 hrm=  0
+340 Fitness Machine Control Point "80 05 01" ResponseCode=128 RequestCode=5 ResultCode=1(Succes)
+334 Indoor Bike Data       "44 00 48 58 fc 00 46 01" status=Power mode speed=226.0 cadence=126 power= 326 hrm=  0
 Stop training session
-...
-18 Fitness Machine Status "02"                      status=Stopped    speed=0 cadence= 99 power=  51 hrm= 90
-...
+337 Fitness Machine Status "02"                      status=Stopped    speed=226.0 cadence=126 power= 326 hrm=  0
+340 Fitness Machine Control Point "80 08 01" ResponseCode=128 RequestCode=8 ResultCode=1(Succes)
+334 Indoor Bike Data       "44 00 ac 58 fe 00 47 01" status=Stopped    speed=227.0 cadence=127 power= 327 hrm=  0
 Release control / reset
-18 Fitness Machine Status "01"                      status=Reset      speed=0 cadence=102 power=  48 hrm= 90
-...
+337 Fitness Machine Status "01"                      status=Reset      speed=227.0 cadence=127 power= 327 hrm=  0
+340 Fitness Machine Control Point "80 01 01" ResponseCode=128 RequestCode=1 ResultCode=1(Succes)
+334 Indoor Bike Data       "44 00 10 59 00 01 48 01" status=Reset      speed=228.0 cadence=128 power= 328 hrm=  0
 Stop collector loop
 Unregister notifications
 Unregister indications
-
 
 """

--- a/examples/FTMSclient.py
+++ b/examples/FTMSclient.py
@@ -1,0 +1,739 @@
+#-------------------------------------------------------------------------------
+# Description
+#-------------------------------------------------------------------------------
+# The bleak library enables python programs to access Bluetooth Low Energy
+# as a client. In out context, a Cycling Training Program is a client and the
+# Tacx Trainer is the server (FTMS FiTness Machine Server)
+#
+# In the FortiusAnt context, we do not need to create a client, because CTP's
+# (like Trainer Road and Zwift) are the client. The reason to have this program
+# is to be able to debug FortiusAnt (ble-mode). This could be done using standard
+# test-programs. But coding a test-client, exactly to the functionality we need,
+# makes us understand how ble works and allows us to test each individual
+# element of the interface.
+#
+# This program does the following:
+# 1. findBLEdevices() check what ble-FTMS devices are alive
+# 2. serverInspection() prints all data of the FTMS device that is found
+#  2a. Open the server as client
+#  2b. Print the server, service, characteristics and descriptions structure
+#  Then:
+#  2c. Register to receive notifications and indications
+#      Notifications are messages that are sent on server-initiative
+#      Indications   are responses to actions we do
+#  2d. The we simulate a CTP.
+#      We send a request to the server and wait for a response in a sequence:
+#    2dI.   Request Control = ask permission that we are allowed to proceed
+#    2dII.  Start           = start a training session
+#    2dIII. Power/GradeMode = request trainer to provide a resistance, either
+#                             expressed in Watt or Slope%
+#    2dIV.  Stop            = end training session
+#    2dV.   Reset           = release access 
+#  2e. Unregister notifications and indications
+#
+# This program can be used as follows:
+# 1. Start FortiusAnt.py -g -a -s -b (gui, autostart, simulation, bluetooth)
+#       FortiusAnt will now listen for commands, no trainer is required (-s)
+#       and dispplay what is going on on the user-interface
+# 2. Start bleBleak.py
+#       You will see that "a CTP" session is running, requesting:
+#       325 Watt, 5%, 324 Watt, 4%, ..., 320 Watt, 0%, 50Watt
+#
+# And of course, in this way, we can automatically test FortiusAnt in ble-mode
+#
+# NOTES:
+# - The code is quite lineair and not in classes; the code is not intended to 
+#   provide a basis for usages in larger environments but serves as a demo/test
+#   only
+#-------------------------------------------------------------------------------
+# Author        https://github.com/WouterJD
+#               wouter.dubbeldam@xs4all.nl
+#-------------------------------------------------------------------------------
+# Version info
+#-------------------------------------------------------------------------------
+__version__ = "2022-03-14"
+# 2022-03-16    bleBleak.py works on Windows 10
+#               - sometimes the BLE dongle must be reset (remove/insert)
+#               - sometimes indications are not received
+#                   This SEEMS to have gone since Try/Except is used (?)
+# 2022-03-16    retries in discovery and finding client introduced.
+# 2022-03-14    read_gatt_char() accepts UUID or HANDLE,
+#               Tests with Tacx NEO show that duplicate UUID's exist, so
+#                   handle is used as input.
+# 2022-02-22    bleBleak.py works on rpi0W with raspbian v10 buster
+# 2022-02-21    Version rebuilt to be able to validate the FortiusAnt/BLE 
+#               implementation and I expect you could 'look' at an existing
+#               Tacx-trainer as well, but did not try that.
+#
+#               FortiusAnt/BLE using NodeJS does not transmit:
+#               - the trainer speed in the FTMS
+#
+# 2020-12-18    First version, obtained from: " hbldh\bleak"
+#               Service Explorer
+#               ----------------
+#               An example showing how to access and print out the services,
+#               characteristics anddescriptors of a connected GATT server.
+#
+#               Created on 2019-03-25 by hbldh <henrik.blidh@nedomkull.com>
+#-------------------------------------------------------------------------------
+import asyncio
+import logging
+import os
+from socket import timeout
+
+from bleak import BleakClient
+from bleak import discover
+from bleak import __version__ as bleakVersion
+
+import struct
+
+BlessExample = True
+if not BlessExample:
+    #---------------------------------------------------------------------------
+    # Import in the FortiusAnt context
+    #---------------------------------------------------------------------------
+    from   constants            import mode_Power, mode_Grade, UseBluetooth
+    from   logfile              import HexSpace
+    from   bleBlessClass        import clsBleServer
+    import bleConstants         as bc
+
+if BlessExample:
+    #---------------------------------------------------------------------------
+    # Import and Constants for bless example context
+    #---------------------------------------------------------------------------
+    import FTMSconstants        as bc
+
+    def HexSpace(info):
+        return (info)
+
+
+#-------------------------------------------------------------------------------
+# Status feb 2022:
+#-------------------------------------------------------------------------------
+# Notes on Windows 10 Pro, version 21H2, build 19044.1526
+#                          Windows Feature Experience Pack 120.2212.4170.0
+# - no BLE device: "await discover()" does not return devices and no error.
+# - standard "Thinkpad bluetooth 4.0" adaptor: indications are not received
+# - Realtek Bluetooth 5.0 adaptor:             same
+#
+# When indications are not received, the simulation loop does not work
+#-------------------------------------------------------------------------------
+# Raspberry rpi0W with Raspbian version (10) buster
+# - bleBleak.py works; sample output added to end-of-this-file.
+#-------------------------------------------------------------------------------
+print("bleak = %s" % bleakVersion)
+if os.name == 'nt':
+    print("************************************************************************")
+    print("***** bleBleak.py works under Windows 10; but is not always stable *****")
+    print("************************************************************************\n\n")
+
+#-------------------------------------------------------------------------------
+# ADDRESSES: Returned by findBLEdevices()
+#-------------------------------------------------------------------------------
+global ADDRESSES
+ADDRESSES = []        # The address appears appear to change continuously
+
+#-------------------------------------------------------------------------------
+# Status-fields of the Fitness Machine
+#-------------------------------------------------------------------------------
+global cadence, hrm, power, speed, status
+cadence, hrm, power, speed, status = (0, 0, 0, 0, 'initial')
+
+#-------------------------------------------------------------------------------
+# FitnessMachineControlPoint indicated response fields
+#-------------------------------------------------------------------------------
+global ResultCode, ResultCodeText
+ResultCode, ResultCodeText = (None, None)
+
+#-------------------------------------------------------------------------------
+# f i n d B L E D e v i c e s
+#-------------------------------------------------------------------------------
+# Input:    bleak devices
+#
+# Function  Discover existing devices and return list of addresses
+#
+# Output:   ADDRESSES
+#-------------------------------------------------------------------------------
+async def findBLEdevices():
+    global ADDRESSES
+    print('-------------------------------')
+    print(' Discover existing BLE devices ')
+    print('-------------------------------')
+    retry = 5
+    while retry:
+        devices = await discover()
+        if len(devices):
+            break
+        else:
+            retry -= 1
+            print('No devices found, retry')
+
+    for d in devices:
+        # print('d -----------------------------')
+        # print('\n'.join("%s: %s" % item for item in vars(d).items()))
+        # print('d --------------------------end')
+        ftms = True         # Defines what to do with unknown devices
+        try:
+            # The following are NOT fitness machines (saves inspection time)
+            if (    'Forerunner' in d.name
+                or  'Garmin' in d.name):
+                ftms = False
+
+            # The following ARE fitness machines
+            if (    bc.sFitnessMachineUUID in d.metadata['uuids']
+                or  'FortiusANT' in d.name
+                or  d.name == 'Unknown'
+                or  d.name[:3] == 'LT-'):
+                ftms = True
+
+        except Exception as e:
+            pass
+        if ftms:
+            ADDRESSES.append (d.address) # It's a candidate, more checks later
+            print(d, 'will be inspected')
+        else:
+            print(d)
+
+#-------------------------------------------------------------------------------
+# s e r v e r I n s p e c t i o n
+#-------------------------------------------------------------------------------
+# Input:    address
+#
+# Function  Inspect structure of the provided server
+#
+# Output:   Console
+#-------------------------------------------------------------------------------
+async def serverInspection(address):
+    print('---------------------------------------------------')
+    print(' Inspect BLE-device with address %s' % address)
+    print('---------------------------------------------------')
+    retry = 5
+    while retry:
+        try:
+            async with BleakClient(address) as client: # , timeout=100
+                await serverInspectionSub(client)
+            break
+        except Exception as e:
+            if 'TimeoutError' in str(type(e)):
+                print('Timeout, retry')
+                retry -= 1
+            else:
+                print(type(e), e)
+                break
+            
+async def serverInspectionSub(client):
+
+    print("Connected: ", client.is_connected)
+    # print('client -----------------------------')
+    # print('\n'.join("%s: %s" % item for item in vars(client).items()))
+    # print('client --------------------------end')
+
+    #---------------------------------------------------------------------------
+    # Get Generic Access Profile
+    # This service is not always available in client.services, but the 
+    # characteristics can always be retrieved.
+    # See issue https://github.com/hbldh/bleak/issues/782
+    #---------------------------------------------------------------------------
+    try:
+        sServiceDeviceName = await client.read_gatt_char(bc.cDeviceNameUUID)
+        sServiceDeviceName = sServiceDeviceName.decode('ascii')
+        if sServiceDeviceName == '': sServiceDeviceName = '<Empty>'
+        print("%s=%s" % (bc.cDeviceNameName, sServiceDeviceName))
+    except Exception as e:
+        sServiceDeviceName = '<Unknown name>'
+        print("Characteristic %s error=%s" % (bc.cDeviceNameName, e))
+
+    try:
+        Appearance = await client.read_gatt_char(bc.cAppearanceUUID)
+        print("%s=%s" % (bc.cAppearanceName, Appearance))
+    except Exception as e:
+        Appearance = None
+        print("Characteristic %s error=%s" % (bc.cAppearanceName, e))
+
+    #---------------------------------------------------------------------------
+    # Check whether this service is a Fitness Machine
+    # by inspecting the FitnessMachineFeature characteristic.
+    #---------------------------------------------------------------------------
+    bFitnessMachine    = False
+    sFitnessMachine    = 'NOT '
+
+    try:
+        value = bytes(await client.read_gatt_char(bc.cFitnessMachineFeatureUUID))
+    except Exception as e:
+        print("Characteristic %s error=%s" % (bc.cFitnessMachineFeatureName, e))
+        value = None
+    else:
+        #-----------------------------------------------------------------------
+        # If present with expected length (otherwise unpack crashes)
+        # check if the expected flagsd are present.
+        #-----------------------------------------------------------------------
+        if len(value) == 8:
+            tuple  = struct.unpack (bc.little_endian + bc.unsigned_long * 2, value)
+            cFitnessMachineFeatureFlags1 = tuple[0]
+            cFitnessMachineFeatureFlags2 = tuple[1]
+
+            if (    cFitnessMachineFeatureFlags1 & bc.fmf_CadenceSupported
+                and cFitnessMachineFeatureFlags1 & bc.fmf_PowerMeasurementSupported
+                and cFitnessMachineFeatureFlags2 & bc.fmf_PowerTargetSettingSupported
+                and cFitnessMachineFeatureFlags2 & bc.fmf_IndoorBikeSimulationParametersSupported
+                ):
+                bFitnessMachine = True
+                sFitnessMachine = ''
+
+    print ('%s: This is %sa matching Fitness Machine' % (sServiceDeviceName, sFitnessMachine) )
+
+    #---------------------------------------------------------------------------
+    # Inspect the Fitness Machine and print all details
+    #---------------------------------------------------------------------------
+    if bFitnessMachine:
+        #-----------------------------------------------------------------------
+        # Inspect all services of the server
+        #-----------------------------------------------------------------------
+        for service in client.services:
+            s = "Service: %s" % service
+            s = s.replace(bc.BluetoothBaseUUIDsuffix, '-...')  # Always the same
+            print(s)
+            #-------------------------------------------------------------------
+            # Inspect all characteristics of the service
+            #-------------------------------------------------------------------
+            for char in service.characteristics:
+                #---------------------------------------------------------------
+                # Print characteristic, properties and value
+                #---------------------------------------------------------------
+                if "read" in char.properties:
+                    #-----------------------------------------------------------
+                    # Use handle, which is unique by definition.
+                    # (Tacx Neo caused duplicate uuid)
+                    #-----------------------------------------------------------
+                    try:
+                        value = bytes(await client.read_gatt_char(char.handle))
+                    except Exception as e:
+                        value = e
+                elif "notify" in char.properties:
+                    value = '(N/A: Wait for notification)'      # Initiated by server
+                elif "indicate" in char.properties and "write" in char.properties:
+                    value = '(N/A: Wait for indication)'        # Requested by client
+                else:
+                    value = '(N/A; not readable)'
+
+                if char.uuid == bc.cDeviceNameUUID:
+                    s = '"' + value.decode('ascii') + '"'       # Device name should be printable
+                else:
+                    s = HexSpace(value)
+
+                s = '\tCharacteristic: %-80s, props=%s, value=%s' % (char, char.properties, s)
+                s = s.replace(bc.BluetoothBaseUUIDsuffix, '-...') # Always the same
+                print(s)
+
+                #---------------------------------------------------------------
+                # Inspect and print FitnessMachineFeature characteristic
+                # (not used, but could be when implementing a real collector)
+                #---------------------------------------------------------------
+                if char.uuid == bc.cFitnessMachineFeatureUUID and len(value) == 8:
+                    tuple  = struct.unpack (bc.little_endian + bc.unsigned_long * 2, value)
+                    cFitnessMachineFeatureFlags1 = tuple[0]
+                    cFitnessMachineFeatureFlags2 = tuple[1]
+
+                    print('\t\tSupported: ', end='')
+                    if cFitnessMachineFeatureFlags1 & bc.fmf_CadenceSupported:                        print('Cadence, '           , end='')
+                    if cFitnessMachineFeatureFlags1 & bc.fmf_HeartRateMeasurementSupported:           print('HRM, '               , end='')
+                    if cFitnessMachineFeatureFlags1 & bc.fmf_PowerMeasurementSupported:               print('PowerMeasurement, '  , end='')
+                    if cFitnessMachineFeatureFlags2 & bc.fmf_PowerTargetSettingSupported:             print('PowerTargetSetting, ', end='')
+                    if cFitnessMachineFeatureFlags2 & bc.fmf_IndoorBikeSimulationParametersSupported: print('IndoorBikeSimulation', end='')
+                    print('.')
+
+                #---------------------------------------------------------------
+                # Inspect all descriptors of the characteristic
+                #---------------------------------------------------------------
+                for descriptor in char.descriptors:
+                    if descriptor.uuid != bc.CharacteristicUserDescriptionUUID:
+                        try:
+                            value = bytes(
+                                await client.read_gatt_descriptor(descriptor.handle)
+                            )
+                        except Exception as e:
+                            value = e
+
+                        # Does not seem to provide much additional information,
+                        # So commented, perhaps for later use
+                        # print("\t\tDescriptor: ", descriptor.uuid, 'value=', HexSpace(value))
+
+        #-----------------------------------------------------------------------
+        # Now receive notifications and indications
+        #-----------------------------------------------------------------------
+        print("Register notifications")
+        try:
+            await client.start_notify(bc.cFitnessMachineStatusUUID, notificationFitnessMachineStatus)
+        except Exception as e:
+            print ('Registration failed', e)
+
+        try:
+            await client.start_notify(bc.cHeartRateMeasurementUUID, notificationHeartRateMeasurement)
+        except Exception as e:
+            print ('Registration failed', e)
+
+        try:
+            await client.start_notify(bc.cIndoorBikeDataUUID,       notificationIndoorBikeData)
+        except Exception as e:
+            print ('Registration failed', e)
+
+        print("Register indications")
+        try:
+            await client.start_notify(bc.cFitnessMachineControlPointUUID, indicationFitnessMachineControlPoint)
+        except Exception as e:
+            print ('Registration failed', e)
+
+        print("------------------------------------------------------")
+        print(" Start simulation of a Cycling Training Program (CTP) ")
+        print("------------------------------------------------------")
+        global ResultCode, ResultCodeText
+        mode      = bc.fmcp_RequestControl  # ControlPoint opcodes are used
+        PowerMode = 0x0100                  # Additional mode (no opcode)
+        GradeMode = 0x0200
+        StopMode  = 0x0300
+        waitmode  = 0x1000  # Range outside opcodes, to indicate waiting
+        CountDown = 5       # Number of cycles between PowerMode / GradeMode
+        timeout   = 10      # Initial value for wait
+        wait      = timeout # Waiting for confirmation of response
+        ResultCode= None    # No response received
+        while True:
+            if mode >= waitmode:
+                #---------------------------------------------------------------
+                # mode contains the next step to be done + waitmode
+                # Check the ResultCode first and act accordingly
+                #---------------------------------------------------------------
+                if ResultCode == None:
+                    print("Waiting for response on FitnessMachineControlPoint request")
+                    wait -= 1                   # Keep waiting
+                    if not wait:
+                        print("Timeout on waiting!!")
+                        mode = StopMode         # Stop the loop
+
+                elif ResultCode == bc.fmcp_Success:
+                    # print('ResultCode = success, proceed')
+                    mode = mode - waitmode      # Proceed with next action
+
+                    #-----------------------------------------------------------
+                    # Prepare for next wait mode
+                    #-----------------------------------------------------------
+                    ResultCode = None
+                    wait       = timeout
+
+                else:
+                    print('Error: FitnessMachineControlPoint request failed with ResultCode = %s (%s)' % (ResultCode, ResultCodeText))
+                    break
+
+            elif mode == StopMode:
+                #---------------------------------------------------------------
+                print("Stop collector loop")
+                #---------------------------------------------------------------
+                break
+
+            elif mode == bc.fmcp_RequestControl:
+                #---------------------------------------------------------------
+                print("Request control, so that commands can be sent")
+                #---------------------------------------------------------------
+                info = struct.pack(bc.little_endian + bc.unsigned_char, bc.fmcp_RequestControl)
+                await client.write_gatt_char(bc.cFitnessMachineControlPointUUID, info)
+
+                # Wait for response and prepare next mode
+                mode = bc.fmcp_StartOrResume + waitmode
+
+            elif mode == bc.fmcp_StartOrResume:
+                #---------------------------------------------------------------
+                print("Start training session")
+                #---------------------------------------------------------------
+                info = struct.pack(bc.little_endian + bc.unsigned_char, bc.fmcp_StartOrResume)
+                await client.write_gatt_char(bc.cFitnessMachineControlPointUUID, info)
+
+                # Wait for response and next mode
+                mode = PowerMode + waitmode
+
+            elif mode == PowerMode:
+                CountDown -= 1
+                if CountDown:
+                    TargetPower = 320 + CountDown   # Watts
+                else:
+                    TargetPower = 50                # Watts, final power
+                #---------------------------------------------------------------
+                print('Switch to PowerMode, %sW' % TargetPower)
+                #---------------------------------------------------------------
+                info = struct.pack(bc.little_endian + bc.unsigned_char + bc.unsigned_short, 
+                                                bc.fmcp_SetTargetPower,  TargetPower      )
+                await client.write_gatt_char(bc.cFitnessMachineControlPointUUID, info)
+
+                # Wait for response and prepare next mode
+                if CountDown:   mode = GradeMode + waitmode
+                else:           mode = bc.fmcp_StopOrPause + waitmode
+
+            elif mode == GradeMode:
+                TargetGrade = CountDown  # % inclination
+                windspeed   = 0
+                crr         = 0.004      # rolling resistance coefficient
+                cw          = 0.51       # wind resistance coefficient
+                #---------------------------------------------------------------
+                print('Switch to GradeMode, %s%%' % TargetGrade)
+                #---------------------------------------------------------------
+                TargetGrade = int(TargetGrade * 100)    # Resolution 0.01
+                windspeed   = int(windspeed * 1000)     # Resolution 0.001
+                crr         = int(crr * 10000)          # Resolution 0.0001
+                cw          = int(cw  *   100)          # Resolution 0.01
+                info = struct.pack(bc.little_endian + bc.unsigned_char + bc.short + bc.short   + bc.unsigned_char + bc.unsigned_char,
+                                   bc.fmcp_SetIndoorBikeSimulation,      windspeed, TargetGrade, crr,               cw)
+                await client.write_gatt_char(bc.cFitnessMachineControlPointUUID, info)
+
+                # Wait for response and prepare next mode
+                mode = PowerMode + waitmode
+
+            elif mode == bc.fmcp_StopOrPause:
+                #---------------------------------------------------------------
+                print("Stop training session")
+                #---------------------------------------------------------------
+                info = struct.pack(bc.little_endian + bc.unsigned_char, bc.fmcp_StopOrPause)
+                await client.write_gatt_char(bc.cFitnessMachineControlPointUUID, info)
+
+                # Wait for response and prepare next mode
+                mode = bc.fmcp_Reset + waitmode
+
+            elif mode == bc.fmcp_Reset:
+                #---------------------------------------------------------------
+                print("Release control / reset")
+                #---------------------------------------------------------------
+                info = struct.pack(bc.little_endian + bc.unsigned_char, bc.fmcp_Reset)
+                await client.write_gatt_char(bc.cFitnessMachineControlPointUUID, info)
+
+                # Wait for response and prepare next mode
+                mode = StopMode + waitmode
+
+            else:
+                #---------------------------------------------------------------
+                print("Unknown mode %s" % mode)
+                #---------------------------------------------------------------
+
+            #-------------------------------------------------------------------
+            # Pause for a second before next action done
+            # (If next action is wait, only 0.1 second)
+            #-------------------------------------------------------------------
+            if mode >= waitmode:
+                await asyncio.sleep(0.1)    # When waiting, short timeout
+            else:
+                await asyncio.sleep(1)      # Next action after a second
+
+        #-----------------------------------------------------------------------
+        # Stop receiving notifications and indications
+        #-----------------------------------------------------------------------
+        print("Unregister notifications")
+        try:
+            await client.stop_notify(bc.cFitnessMachineStatusUUID)
+        except Exception as e:
+            pass
+        try:
+            await client.stop_notify(bc.cHeartRateMeasurementUUID)
+        except Exception as e:
+            pass
+        try:
+            await client.stop_notify(bc.cIndoorBikeDataUUID)
+        except Exception as e:
+            pass
+
+        print("Unregister indications")
+        try:
+            await client.stop_notify(bc.cFitnessMachineControlPointUUID)
+        except Exception as e:
+            pass
+
+#-------------------------------------------------------------------------------
+# n o t i f i c a t i o n   A N D   i n d i c a t i o n   H a n d l e r s
+#-------------------------------------------------------------------------------
+# Input:    handle, data
+#
+# Function  Notification handler to print the notified data
+#
+# Output:   Console
+#           HeartRateMeasurement; hrm
+#           IndoorBikeData;       cadence, hrm, speed, power
+#-------------------------------------------------------------------------------
+def indicationFitnessMachineControlPoint(handle, data):
+    global ResultCode, ResultCodeText
+
+    if len(data) >= 1: ResponseCode      = int(data[0]) # Always 0x80
+    if len(data) >= 2: RequestCode       = int(data[1]) # The requested OpCode
+    if len(data) >= 3: ResultCode        = int(data[2]) # e.g. fmcp_Success 
+    # ResponseParameter not implemented, variable format
+
+    if   ResultCode == bc.fmcp_Success:             ResultCodeText = 'Succes'
+    elif ResultCode == bc.fmcp_OpCodeNotSupported:  ResultCodeText = 'OpCodeNotSupported'
+    elif ResultCode == bc.fmcp_InvalidParameter:    ResultCodeText = 'InvalidParameter'
+    elif ResultCode == bc.fmcp_OperationFailed:     ResultCodeText = 'OperationFailed'
+    elif ResultCode == bc.fmcp_ControlNotPermitted: ResultCodeText = 'ControlNotPermitted'
+    else:                                           ResultCodeText = '?'
+
+    if True:   # For debugging only
+        print("%s %s %s ResponseCode=%s RequestCode=%s ResultCode=%s(%s)" %
+            (handle, bc.cFitnessMachineControlPointName, HexSpace(data),
+            ResponseCode, RequestCode, ResultCode, ResultCodeText))
+
+def notificationFitnessMachineStatus(handle, data):
+    global status
+    OpCode = int(data[0])
+    # ResponseParameter not implemented, variable format
+
+    if   OpCode == bc.fms_Reset:                                 status = 'Reset'
+    elif OpCode == bc.fms_FitnessMachineStoppedOrPausedByUser:   status = 'Stopped' # or Paused
+    elif OpCode == bc.fms_FitnessMachineStartedOrResumedByUser:  status = 'Started' # or Resumed
+    elif OpCode == bc.fms_TargetPowerChanged:                    status = 'Power mode'
+    elif OpCode == bc.fms_IndoorBikeSimulationParametersChanged: status = 'Grade mode'
+    else:                                                        status = '?'
+
+    notificationPrint(handle, bc.cFitnessMachineStatusName, data)
+
+def notificationHeartRateMeasurement(handle, data):
+    global cadence, hrm, speed, power
+    if len(data) == 2:
+        tuple  = struct.unpack (bc.little_endian + bc.unsigned_char * 2, data)
+        flags   = tuple[0]
+        hrm     = tuple[1]
+    else:
+        print('Error in notificationHeartRateMeasurement(): unexpected data length')
+
+    notificationPrint(handle, bc.cHeartRateMeasurementName, data)
+
+def notificationIndoorBikeData(handle, data):
+    global cadence, hrm, speed, power
+
+    if len(data) in (4,6,8,10): # All flags should be implemented; only this set done!!
+        tuple  = struct.unpack (bc.little_endian + bc.unsigned_short * int(len(data)/2), data)
+        flags   = tuple[0]
+        speed   = tuple[1] / 100         # always present, transmitted in 0.01 km/hr
+        n = 2
+        if flags & bc.ibd_InstantaneousCadencePresent:
+            cadence = int(tuple[n] / 2)  # Because transmitted in BLE in half rpm
+            n += 1
+        if flags & bc.ibd_InstantaneousPowerPresent:
+            power   = tuple[n]
+            n += 1
+        if flags & bc.ibd_HeartRatePresent:
+            hrm    = tuple[n]
+            n += 1
+    else:
+        print('Error in notificationIndoorBikeData(): unexpected data length')
+
+    notificationPrint(handle, bc.cIndoorBikeDataName, data)
+
+#-------------------------------------------------------------------------------
+# n o t i f i c a t i o n P r i n t
+#-------------------------------------------------------------------------------
+# Input:    globals
+#
+# Function  After receiving a notification or indication, print info on FTMS
+#
+# Output:   printed info
+#-------------------------------------------------------------------------------
+def notificationPrint(handle, uuidName, data):
+    global cadence, hrm, speed, power, status
+
+    print("%s %-22s %-25s status=%-10s speed=%4.1f cadence=%3s power=%4s hrm=%3s" % 
+        (handle, uuidName, HexSpace(data), 
+         status, round(speed,1), cadence, power, hrm)
+         )
+
+
+if __name__ == "__main__":
+    #---------------------------------------------------------------------------
+    # Introduction
+    #---------------------------------------------------------------------------
+    print('bleBleak.py is used to show the characteristics of a running FTMS (Fitness Machine Service).')
+    print('FortiusAnt (BLE) provides such an FTMS and a Cycling Training Program is a client for that service.')
+    print('Note that, when a CTP is active, FortiusAnt will not be discovered because it is in use.')
+    print('')
+    print('After having displayed the characteristics, a CTP-simulation is done.')
+    print('- Commands are sent to the FTMS: RequestControl, Start, Power/Grade, Stop and Reset')
+    print('- PowerMode/GradeMode is done 5 times, setting the different targets alternatingly')
+    print('While performing above requests, the results from the FTMS are displayed.')
+    print('')
+    print('In this way, the FortiusAnt BLE-interface can be tested:')
+    print('First start FortiusAnt with -g -a -s -b to activate BLE and simulation-mode')
+    print('Then  start bleBleak to print the characteristics and execute the test')
+
+    #---------------------------------------------------------------------------
+    # Initialize logger, currently straight print() used
+    # Logging for bleak can be activated here
+    #---------------------------------------------------------------------------
+    logger = logging.getLogger(__name__)
+    #logging.basicConfig(level=logging.INFO)
+    #logging.basicConfig(level=logging.DEBUG)
+
+    #---------------------------------------------------------------------------
+    # First discover ADDRESSES of all possible fitness machines (1 expected)
+    #---------------------------------------------------------------------------
+    asyncio.run(findBLEdevices())
+
+    #---------------------------------------------------------------------------
+    # Now show all details of the FTMS
+    #---------------------------------------------------------------------------
+    for a in ADDRESSES:
+        asyncio.run(serverInspection(a))
+
+"""
+
+SAMPLE OUTPUT:
+==============
+
+-------------------------------
+ Discover existing BLE devices 
+-------------------------------
+75:A1:76:76:46:49: 75-A1-76-76-46-49
+5C:F3:70:9F:8C:98: FortiusANT Trainer
+24:B7:A7:30:5A:01: 24-B7-A7-30-5A-01
+---------------------------------------------------
+ Inspect BLE-device with address 5C:F3:70:9F:8C:98
+---------------------------------------------------
+Connected:  True
+<Unknown>: This is a matching Fitness Machine
+Service: 0000180d-... (Handle: 29): Heart Rate
+	Characteristic: 00002a37-... (Handle: 30): Heart Rate Measurement       , props=['notify'], value="(N/A: Wait for notification)"
+Service: 00001826-... (Handle: 10): Fitness Machine
+	Characteristic: 00002ad8-... (Handle: 26): Supported Power Range        , props=['read'], value="00 00 e8 03 01 00"
+	Characteristic: 00002ad9-... (Handle: 22): Fitness Machine Control Point, props=['write', 'indicate'], value="(N/A: Wait for indication)"
+	Characteristic: 00002ada-... (Handle: 18): Fitness Machine Status       , props=['notify'], value="(N/A: Wait for notification)"
+	Characteristic: 00002ad2-... (Handle: 14): Indoor Bike Data             , props=['notify'], value="(N/A: Wait for notification)"
+	Characteristic: 00002acc-... (Handle: 11): Fitness Machine Feature      , props=['read'], value="02 40 00 00 08 20 00 00"
+		Supported: Cadence, PowerMeasurement, PowerTargetSetting, IndoorBikeSimulation.
+Service: 00001801-... (Handle: 6): Generic Attribute Profile
+	Characteristic: 00002a05-... (Handle: 7): Service Changed               , props=['indicate'], value="(N/A; not readable)"
+Register notifications
+14 Indoor Bike Data       "44 00 00 00 c4 00 31 00" status=initial    speed=0 cadence= 98 power=  49 hrm=  0
+30 Heart Rate Measurement "00 5f"                   status=initial    speed=0 cadence= 98 power=  49 hrm= 95
+Register indications
+------------------------------------------------------
+ Start simulation of a Cycling Training Program (CTP) 
+------------------------------------------------------
+Request control, so that commands can be sent
+14 Indoor Bike Data       "44 00 00 00 c6 00 31 00" status=initial    speed=0 cadence= 99 power=  49 hrm= 95
+30 Heart Rate Measurement "00 57"                   status=initial    speed=0 cadence= 99 power=  49 hrm= 87
+...
+Start training session
+18 Fitness Machine Status "04"                      status=Started    speed=0 cadence=100 power=  51 hrm= 85
+...
+Switch to PowerMode, 324W
+14 Indoor Bike Data       "44 00 00 00 ca 00 31 00" status=Started    speed=0 cadence=101 power=  49 hrm= 85
+...
+Switch to GradeMode, 4%
+18 Fitness Machine Status "12 00 00 04 00 00 00"    status=Grade mode speed=0 cadence= 97 power= 145 hrm=105
+...
+Switch to PowerMode, 50W
+18 Fitness Machine Status "08 32 00"                status=Power mode speed=0 cadence=101 power= 340 hrm=184
+...
+Stop training session
+...
+18 Fitness Machine Status "02"                      status=Stopped    speed=0 cadence= 99 power=  51 hrm= 90
+...
+Release control / reset
+18 Fitness Machine Status "01"                      status=Reset      speed=0 cadence=102 power=  48 hrm= 90
+...
+Stop collector loop
+Unregister notifications
+Unregister indications
+
+
+"""

--- a/examples/FTMSconstants.py
+++ b/examples/FTMSconstants.py
@@ -4,20 +4,31 @@
 #-------------------------------------------------------------------------------
 # Version info
 #-------------------------------------------------------------------------------
-__version__ = "2022-03-08"
+__version__ = "2022-03-21"
+# 2022-03-21    Made available to kevincar/bless as example; small modifications
 # 2022-03-08    Constants for bleBleak.py and bleBless.py
 # 2022-02-22    First version
 #-------------------------------------------------------------------------------
 import struct
 
-BlessExample = True
-if not BlessExample:
+#-------------------------------------------------------------------------------
+# To distribute to bless/examples, proceed as follows:
+# - Copy bleBless.py, bleBlessClass and bleConstants   bleBleak.py to hbldh\bless\examples
+#        FTMSserver   FTMSserverClass   FTMSconstants  FTMSclient
+# - Change below "If True:" into "If False:" (and similar in bleBleak/bleBless)
+#       like this, precompiler "knows" that code is unused.
+# - Check bleBleak/bleBless for BlessExample
+#-------------------------------------------------------------------------------
+if False:
+    BlessExample = False
     #---------------------------------------------------------------------------
     # Import in the FortiusAnt context
     #---------------------------------------------------------------------------
-    from   structConstants      import little_endian, unsigned_char, unsigned_short, unsigned_long  # pylint: disable=import-error
+    from   structConstants      import little_endian, unsigned_char, short, unsigned_short, unsigned_long  # pylint: disable=import-error
+    from   logfile              import HexSpace
 
-if BlessExample:
+else:
+    BlessExample = True
     #---------------------------------------------------------------------------
     # Import and Constants for bless example context
     #---------------------------------------------------------------------------
@@ -26,6 +37,9 @@ if BlessExample:
     short               ='h'    #  short                  integer             2               (3)
     unsigned_short      ='H'    #  unsigned short         integer             2               (3)
     unsigned_long       ='L'    #  unsigned long          integer             4               (3)
+
+    def HexSpace(info):
+        return (info)
 
 #-------------------------------------------------------------------------------
 # Bluetooth standard-defined UUIDs receive special treatment as they are

--- a/examples/FTMSconstants.py
+++ b/examples/FTMSconstants.py
@@ -1,0 +1,125 @@
+#-------------------------------------------------------------------------------
+# Author        https://github.com/WouterJD
+#               wouter.dubbeldam@xs4all.nl
+#-------------------------------------------------------------------------------
+# Version info
+#-------------------------------------------------------------------------------
+__version__ = "2022-03-08"
+# 2022-03-08    Constants for bleBleak.py and bleBless.py
+# 2022-02-22    First version
+#-------------------------------------------------------------------------------
+import struct
+
+BlessExample = True
+if not BlessExample:
+    #---------------------------------------------------------------------------
+    # Import in the FortiusAnt context
+    #---------------------------------------------------------------------------
+    from   structConstants      import little_endian, unsigned_char, unsigned_short, unsigned_long  # pylint: disable=import-error
+
+if BlessExample:
+    #---------------------------------------------------------------------------
+    # Import and Constants for bless example context
+    #---------------------------------------------------------------------------
+    little_endian       ='<'    #  little-endian          standard    none
+    unsigned_char       ='B'    #  unsigned char          integer             1               (3)
+    short               ='h'    #  short                  integer             2               (3)
+    unsigned_short      ='H'    #  unsigned short         integer             2               (3)
+    unsigned_long       ='L'    #  unsigned long          integer             4               (3)
+
+#-------------------------------------------------------------------------------
+# Bluetooth standard-defined UUIDs receive special treatment as they are
+# commonly used throughout the various protocols of the Specification. They are
+# grouped around the Bluetooth Base UUID (xxxxxxxx-0000-1000-8000-00805F9B34FB)
+# and share 96 common bits. (See core specification, 3.B.2.5.1)
+# --> "16-bit UUID Numbers Document.pdf"
+#-------------------------------------------------------------------------------
+# Constants to create the BLE service/characteristics structure
+#-------------------------------------------------------------------------------
+BluetoothBaseUUID               = 'xxxxxxxx-0000-1000-8000-00805f9b34fb'
+BluetoothBaseUUIDsuffix         =         '-0000-1000-8000-00805f9b34fb'
+CharacteristicUserDescriptionUUID='00002901-0000-1000-8000-00805f9b34fb'
+
+sGenericAccessUUID              = '00001800-0000-1000-8000-00805f9b34fb'
+sGenericAccessUUID_private      = '19590705-0000-1000-8000-00805f9b34fb'
+cDeviceNameUUID                 = '00002a00-0000-1000-8000-00805f9b34fb'
+cDeviceNameName                 = 'Device Name'
+cAppearanceUUID                 = '00002a01-0000-1000-8000-00805f9b34fb'
+cAppearanceName                 = 'Appearance'
+# Service
+sFitnessMachineUUID             = "00001826-0000-1000-8000-00805f9b34fb"
+sFitnessMachineName             = "Fitness Machine"
+# Service characteristics
+cFitnessMachineFeatureUUID      = "00002acc-0000-1000-8000-00805f9b34fb"
+cFitnessMachineFeatureName      = "Fitness Machine Feature"
+fmf_CadenceSupported                        = 1 <<  1
+fmf_HeartRateMeasurementSupported           = 0       # 1 << 10; CTP's do not expect heartrate to be supplied by Fitness Machine
+fmf_PowerMeasurementSupported               = 1 << 14
+fmf_PowerTargetSettingSupported             = 1 <<  3
+fmf_IndoorBikeSimulationParametersSupported = 1 << 13
+                                # FM Service, section 4.3 p 19:                         features (32 bits), Target settings features (32 bits)
+fmf_Info                        = struct.pack(little_endian + unsigned_long * 2,  fmf_CadenceSupported                        |
+                                                                                  fmf_HeartRateMeasurementSupported           |
+                                                                                  fmf_PowerMeasurementSupported,
+                                                                                  fmf_PowerTargetSettingSupported             |
+                                                                                  fmf_IndoorBikeSimulationParametersSupported )
+
+cIndoorBikeDataUUID                 = "00002ad2-0000-1000-8000-00805f9b34fb"
+cIndoorBikeDataName                 = "Indoor Bike Data"
+ibd_InstantaneousSpeedIsNotPresent  = 0         # Bit 0     # Present unless flagged that it's not
+ibd_InstantaneousCadencePresent     = 1 << 2    # Bit 2
+ibd_InstantaneousPowerPresent       = 1 << 6    # Bit 6
+ibd_HeartRatePresent                = 1 << 9    # Bit 9
+ibd_Flags                           = 0
+                                    # FM Service, section 4.9 p 44: Flags, Cadence, Power, HeartRate
+ibd_Info                            = struct.pack(little_endian + unsigned_short * 4, 
+                                                ibd_InstantaneousPowerPresent | ibd_HeartRatePresent,
+                                                123, 456, 89
+                                                )
+
+cFitnessMachineStatusUUID       = "00002ada-0000-1000-8000-00805f9b34fb"
+cFitnessMachineStatusName       = "Fitness Machine Status"
+                                # FM Service, section 4.17 p 56:                OpCode (UnsignedINT8), Parameter
+fms_Reset                                 = 0x01
+fms_FitnessMachineStoppedOrPausedByUser   = 0x02
+fms_FitnessMachineStartedOrResumedByUser  = 0x04
+fms_TargetPowerChanged                    = 0x08
+fms_IndoorBikeSimulationParametersChanged = 0x12
+
+
+cFitnessMachineControlPointUUID = "00002ad9-0000-1000-8000-00805f9b34fb"
+cFitnessMachineControlPointName = "Fitness Machine Control Point"
+                                # FM Service, section 4.16 p 50:                OpCode (UnsignedINT8), Parameter
+fmcp_RequestControl             = 0x00
+fmcp_Reset                      = 0x01
+fmcp_SetTargetPower             = 0x05
+fmcp_StartOrResume              = 0x07
+fmcp_StopOrPause                = 0x08
+fmcp_SetIndoorBikeSimulation    = 0x11
+fmcp_ResponseCode               = 0x80
+
+fmcp_Success                    = 0x01
+fmcp_OpCodeNotSupported         = 0x02
+fmcp_InvalidParameter           = 0x03
+fmcp_OperationFailed            = 0x04
+fmcp_ControlNotPermitted        = 0x05
+
+cSupportedPowerRangeUUID        = "00002ad8-0000-1000-8000-00805f9b34fb"
+cSupportedPowerRangeName        = "Supported Power Range"
+                                # FM Service, section 4.14 p 49:                  Min, Max,  Increment
+spr_Info                        = struct.pack(little_endian + unsigned_short * 3, 0,   1000, 1)
+
+# Service
+sHeartRateUUID                  = "0000180d-0000-1000-8000-00805f9b34fb"
+sHeartRateName                  = "Heart Rate"
+# Service characteristics
+cHeartRateMeasurementUUID       = "00002a37-0000-1000-8000-00805f9b34fb"
+cHeartRateMeasurementName       = "Heart Rate Measurement"
+                                # HRS_SPEC_V10, section 3.1 p 9:                 Flags, Heartrate
+hrm_Info                        = struct.pack(little_endian + unsigned_char * 2, 0,     123)
+
+# ==============================================================================
+# Main program
+# ==============================================================================
+if __name__ == "__main__":
+    print("bleConstants.py cannot be executed on it's own.")

--- a/examples/FTMSserver.py
+++ b/examples/FTMSserver.py
@@ -1,0 +1,725 @@
+#-------------------------------------------------------------------------------
+# Description
+#-------------------------------------------------------------------------------
+# The bless library enables python programs to access Bluetooth Low Energy
+# as a server. This enables FortiusAnt to create a FTMS (FTMS FiTness Machine Server)
+# and communicate with a CTP (which is the client, refer bleBleak.py).
+#
+# FortiusAnt uses class clsFTMS_bless, based upon clsBleServer
+# This file can be executed and then a simulator is started for demo/test purpose.
+#
+#-------------------------------------------------------------------------------
+# Author        https://github.com/WouterJD
+#               wouter.dubbeldam@xs4all.nl
+#-------------------------------------------------------------------------------
+# Version info
+#-------------------------------------------------------------------------------
+__version__ = "2022-03-08"
+# 2022-03-08    Class to create a bless server split into bleBlessClass.py
+# 2022-03-08    Tested:
+#               - Windows 10 with Trainer Road and Rouvy
+#               - Raspberry  with
+# 2022-03-07    Major revision; make fit to share with bless as example
+# 2022-03-01    Simulation tested on Windows 10 with Trainer Road and Rouvy
+#
+# 2020-12-18    First version, obtained from: " hbldh\bless"
+#               examples\gattserver.py
+#               Example for a BLE 4.0 Server using a GATT dictionary of
+#               characteristics
+#-------------------------------------------------------------------------------
+import struct
+import time
+
+from typing import Any, Dict
+
+from bless import (
+        BlessServer,
+        BlessGATTCharacteristic,
+        GATTCharacteristicProperties,
+        GATTAttributePermissions
+        )
+
+#-------------------------------------------------------------------------------
+# To distribute to bless/examples, proceed as follows:
+# - Copy bleBless.py, bleBlessClass and bleConstants   bleBleak.py to hbldh\bless\examples
+#        FTMSserver   FTMSserverClass   FTMSconstants  FTMSclient
+# - Change BlessExample to True
+# - Check code for BlessExample
+#-------------------------------------------------------------------------------
+BlessExample = True
+if not BlessExample:
+    #---------------------------------------------------------------------------
+    # Import in the FortiusAnt context
+    #---------------------------------------------------------------------------
+    import debug
+    import logfile
+    from   constants            import mode_Power, mode_Grade, UseBluetooth
+    from   logfile              import HexSpace
+    from   bleBlessClass        import clsBleServer
+    import bleConstants         as bc
+
+if BlessExample:
+    #---------------------------------------------------------------------------
+    # Import and Constants for bless example context
+    #---------------------------------------------------------------------------
+    from   FTMSserverClass      import clsBleServer
+    import FTMSconstants        as bc
+
+    import logging
+    mode_Power          = 1     # Target Power
+    mode_Grade          = 2     # Target Resistance
+    UseBluetooth        = True
+
+    def HexSpace(info):
+        return (info)
+
+#-------------------------------------------------------------------------------
+# Define the server structure with services and characteristics
+# 2022-02-22 Note, see https://github.com/kevincar/bless/issues/67
+#            Value should be with a capital, but currently bless uses "value".
+#            Therefore both Value/value are present, to avoid future issues.
+#-------------------------------------------------------------------------------
+
+"""
+    Is not allowed to be added in the GATT definition: failed to create entry in database
+    This 'may be' because it's a standard service, but then: how to set the two characteristics?
+
+    Definition as discovered from NodeJs:
+
+    bc.sGenericAccessUUID: {
+        bc.cDeviceNameUUID: {
+            "Properties":   (GATTCharacteristicProperties.read),
+            "Permissions":  (GATTAttributePermissions.readable | GATTAttributePermissions.writeable),
+            "Value":        b'FortiusAntTrainer',
+            "value":        b'FortiusAntTrainer',
+            "Description":  bc.cDeviceNameName
+        },
+        bc.cAppearanceUUID: {
+            "Properties":   (GATTCharacteristicProperties.read),
+            "Permissions":  (GATTAttributePermissions.readable | GATTAttributePermissions.writeable),
+            "Value":        b'\x80\x00',
+            "value":        b'\x80\x00',
+            "Description":  bc.cAppearanceName
+        },
+    },
+
+    Definition as suggested by Kevin: https://github.com/kevincar/bless/discussions/76#discussioncomment-2380163
+
+    "<YOUR SERVICE UUID>": {
+       bc.cDeviceNameUUID: {
+           "Properties":   (GATTCharacteristicProperties.read | GATTCharacteristicProperties.indicate),
+           "Permissions":  (GATTAttributePermissions.readable),
+           "Value":        "My Device Name",
+           "Description":  bc.cDeviceNameName
+       },
+       bc.cAppearanceUUID: {
+           "Properties":   (GATTCharacteristicProperties.read | GATTCharacteristicProperties.indicate),
+           "Permissions":  (GATTAttributePermissions.readable),
+           "Value":        "My Appearance",
+           "Description":  bc.cAppearanceName
+       }
+    },
+
+    # On Windows 10:
+    #     bc.sGenericAccessUUID: { ... containing the two characteristics ... }
+    #       results in:
+    #           clsBleServer._Server(); add_gatt() exception 'NoneType' object has no attribute 'add_advertisement_status_changed'
+    #
+    #     bc.sFitnessMachineUUID: { ... containing the two characteristics ... }
+    #       results in that characteristic can be read by client, but Trainer Road does still provide TP-T430 as service name.
+    #
+    #     bc.sGenericAccessUUID_private: { ... containing the two characteristics ... }
+    #       has the same effect.
+    #       bleBleak considers the service to be "vendor specific"
+    #
+    # On Raspberry:
+    #     bc.sGenericAccessUUID: { ... containing the two characteristics ... }
+    #       results in:
+    #            clsBleServer._Server(); start() exception org.bluez.Error.Failed: Failed to create entry in database
+    #
+    #     bc.sGenericAccessUUID_private: { ... containing the two characteristics ... }
+    #       This confuses bleak at the Windows 10 side (duplicate keys, FTMS not found)
+
+    "<YOUR SERVICE UUID>": {            # This line is modified as explained above
+        bc.cDeviceNameUUID: {
+            "Properties":   (GATTCharacteristicProperties.read),
+            "Permissions":  (GATTAttributePermissions.readable | GATTAttributePermissions.writeable),
+            "Value":        b'FortiusAntTrainer',
+            "value":        b'FortiusAntTrainer',
+            "Description":  bc.cDeviceNameName
+        },
+        bc.cAppearanceUUID: {
+            "Properties":   (GATTCharacteristicProperties.read),
+            "Permissions":  (GATTAttributePermissions.readable | GATTAttributePermissions.writeable),
+            "Value":        b'\x80\x00',
+            "value":        b'\x80\x00',
+            "Description":  bc.cAppearanceName
+        },
+    },
+"""
+
+FitnessMachineGatt: Dict = {
+    bc.sFitnessMachineUUID: {
+        bc.cFitnessMachineFeatureUUID: {
+            "Properties":   (GATTCharacteristicProperties.read),
+            "Permissions":  (GATTAttributePermissions.readable | GATTAttributePermissions.writeable),
+            "Value":        bc.fmf_Info,                        # b'\x02\x40\x00\x00\x08\x20\x00\x00',
+            "value":        bc.fmf_Info,
+            "Description":  bc.cFitnessMachineFeatureName
+        },
+        bc.cIndoorBikeDataUUID: {
+            "Properties":   (GATTCharacteristicProperties.notify),
+            "Permissions":  (GATTAttributePermissions.readable | GATTAttributePermissions.writeable),
+            "Value":        bc.ibd_Info,                        # Instantaneous Cadence, Power, HeartRate
+            "value":        bc.ibd_Info,
+            "Description":  bc.cIndoorBikeDataName
+        },
+        bc.cFitnessMachineStatusUUID: {
+            "Properties":   (GATTCharacteristicProperties.notify),
+            "Permissions":  (GATTAttributePermissions.readable | GATTAttributePermissions.writeable),
+            "value":        b'\x00\x00',                        # Status as "sent" to Cycling Training Program
+            "Value":        b'\x00\x00',
+            "Description":  bc.cFitnessMachineStatusName
+        },
+        bc.cFitnessMachineControlPointUUID: {
+            "Properties":   (GATTCharacteristicProperties.write | GATTCharacteristicProperties.indicate),
+            "Permissions":  (GATTAttributePermissions.readable | GATTAttributePermissions.writeable),
+            "Value":        b'\x00\x00',                        # Commands as received from Cycling Training Program
+            "value":        b'\x00\x00',
+            "Description":  bc.cFitnessMachineControlPointName
+        },
+        bc.cSupportedPowerRangeUUID: {
+            "Properties":   (GATTCharacteristicProperties.read),
+            "Permissions":  (GATTAttributePermissions.readable | GATTAttributePermissions.writeable),
+            "Value":        bc.spr_Info,                        # Static additional properties of the FTMS
+                                                                # b'\x00\x00\xe8\x03\x01\x00'
+                                                                # min=0, max=1000, incr=1 
+                                                                # ==> 0x0000 0x03e8 0x0001 ==> 0x0000 0xe803 0x0100
+            "value":        bc.spr_Info,
+            "Description":  bc.cSupportedPowerRangeName
+        }
+    },
+    bc.sHeartRateUUID: {
+        bc.cHeartRateMeasurementUUID: {
+            "Properties":   (GATTCharacteristicProperties.notify),
+            "Permissions":  (GATTAttributePermissions.readable | GATTAttributePermissions.writeable),
+            "Value":        bc.hrm_Info,
+            "value":        bc.hrm_Info,
+            "Description":  bc.cHeartRateMeasurementName
+        }
+    }
+}
+
+#-------------------------------------------------------------------------------
+# c l s F T M S _ b l e s s 
+#-------------------------------------------------------------------------------
+# Class to create an FiTnessMachineServer, based upon bless
+#
+# User methods:
+#   See parent class AND
+#
+#   SetAthleteData  Pass Fitness Machine information to the class
+#   SetTrainerData
+#
+#   Refresh()       Must be called before attributes are used
+#
+# User attributes:
+#   See parent class AND
+#   See below
+#-------------------------------------------------------------------------------
+class clsFTMS_bless(clsBleServer):
+    #---------------------------------------------------------------------------
+    # CTP data, received through WriteRequest() and sent by client
+    #---------------------------------------------------------------------------
+    TargetMode          = mode_Power    # Either mode_Power or mode_Grade
+    TargetGrade         = 0             # %
+    TargetPower         = 100           # Watt
+
+    WindResistance      = 0
+    WindSpeed           = 0
+    DraftingFactor      = 1             # Default since not supplied
+    RollingResistance   = 0
+
+    #---------------------------------------------------------------------------
+    # data provided by SetAthleteData() as called by application
+    #---------------------------------------------------------------------------
+    HeartRate           = 0
+
+    #---------------------------------------------------------------------------
+    # data provided by SetTrainerData() as called by application
+    #---------------------------------------------------------------------------
+    CurrentSpeed        = 0             # km/hour
+    Cadence             = 0             # /minute
+    CurrentPower        = 0             # Watt
+
+    #---------------------------------------------------------------------------
+    # Internal workflow control data
+    #---------------------------------------------------------------------------
+    HasControl          = False         # CTP is controlling the FTMS
+    Started             = False         # A CTP training is started
+
+    # --------------------------------------------------------------------------
+    # _ _ i n i t _ _
+    # --------------------------------------------------------------------------
+    # Input     UseBluetooth; a 'compile-time' flag indicating to use BLE
+    #           activate;     command-line flag, indicating to use BLE (-bb)
+    #
+    # Function  Create the instance, FTMS starting is done through Open().
+    #
+    # Output    .Message
+    # --------------------------------------------------------------------------
+    def __init__(self, activate):
+        if UseBluetooth and activate:
+            super().__init__("FortiusAntTrainer", FitnessMachineGatt)
+        else:
+            pass                        # Data structure is created, no actions
+
+    # --------------------------------------------------------------------------
+    # SetAthleteData, SetTrainerData
+    # --------------------------------------------------------------------------
+    # Input     function parameters
+    #
+    # Function  Provide trainer data to the FTMS, to be transmitted to CTP
+    #
+    # Output    OK = False
+    # --------------------------------------------------------------------------
+    def SetAthleteData(self, HeartRate):
+        #-----------------------------------------------------------------------
+        # Logging
+        #-----------------------------------------------------------------------
+        self.logfileWrite("clsFTMS_bless.SetAthleteData(%s)" % HeartRate)
+
+        #-----------------------------------------------------------------------
+        # Remember provided data
+        #-----------------------------------------------------------------------
+        self.HeartRate = HeartRate
+
+        #-----------------------------------------------------------------------
+        # Update heartrate in FTMS
+        #-----------------------------------------------------------------------
+        if self.OK:
+            flags = 0
+            h     = int(self.HeartRate) & 0xff      # Avoid value anomalities
+            info = struct.pack (bc.little_endian + bc.unsigned_char * 2, flags, h)
+            self.BlessServer.get_characteristic(bc.cHeartRateMeasurementUUID).value = info
+            self.BlessServer.update_value(bc.sHeartRateUUID, bc.cHeartRateMeasurementUUID)
+        else:
+            self.logfileConsole("clsFTMS_bless.SetAthleteData() error, interface not open")
+
+    def SetTrainerData(self, CurrentSpeed, Cadence, CurrentPower):
+        #-----------------------------------------------------------------------
+        # Logging
+        #-----------------------------------------------------------------------
+        self.logfileWrite("clsFTMS_bless.SetTrainerData(%s, %s, %s)" % (CurrentSpeed, Cadence, CurrentPower))
+
+        #-----------------------------------------------------------------------
+        # Remember provided data
+        #-----------------------------------------------------------------------
+        self.CurrentSpeed = CurrentSpeed
+        self.Cadence      = Cadence
+        self.CurrentPower = CurrentPower
+
+        #-----------------------------------------------------------------------
+        # Update trainer status in FTMS
+        # Note that: Speed always present UNLESS...)
+        #            HeartRate not transmitted, is not used.
+        #-----------------------------------------------------------------------
+        if self.OK:
+            flags = (bc.ibd_InstantaneousCadencePresent | bc.ibd_InstantaneousPowerPresent)
+            s     = int(self.CurrentSpeed * 100) & 0xffff      # Avoid value anomalities
+            c     = int(self.Cadence * 2)        & 0xffff      # Avoid value anomalities
+            p     = int(self.CurrentPower)       & 0xffff      # Avoid value anomalities
+            info  = struct.pack (bc.little_endian + bc.unsigned_short * 4, flags, s, c, p)
+
+            self.BlessServer.get_characteristic(bc.cIndoorBikeDataUUID).value = info
+            self.BlessServer.update_value(bc.sFitnessMachineUUID, bc.cIndoorBikeDataUUID)
+        else:
+            self.logfileConsole("clsFTMS_bless.SetTrainerData() error, interface not open")
+            
+    # --------------------------------------------------------------------------
+    # C l i e n t D i s c o n n e c t e d
+    # --------------------------------------------------------------------------
+    # Input     None
+    #
+    # Function  Client is disconnected, reset workflow flags to prepare for next
+    #           client-connect
+    #
+    # Output    HasControl and Started
+    # --------------------------------------------------------------------------
+    def ClientDisconnected(self):
+        self.HasControl = False
+        self.Started    = False
+
+    # --------------------------------------------------------------------------
+    # R e f r e s h
+    # --------------------------------------------------------------------------
+    # Input     None
+    #
+    # Function  Refresh data, so that attributes are accurate and can be used.
+    #           Currently no implementation required, could be in future.
+    #           Therefore just return OK
+    #
+    #           self.Refresh() must be called before accessing attributes
+    #
+    # Returns   self.OK
+    # --------------------------------------------------------------------------
+    def Refresh(self):
+        return self.OK
+
+    #---------------------------------------------------------------------------
+    # l o g f i l e W r i t e / C o n s o l e
+    #---------------------------------------------------------------------------
+    # Input:    text to be written to logfile
+    #
+    # Function  Use our own standard logging functions
+    #
+    # Output:   none
+    #---------------------------------------------------------------------------
+    if not BlessExample:            # As used in the FortiusAnt context
+        def logfileWrite(self, message):
+            if debug.on(debug.Ble): logfile.Write(message)
+
+        def logfileConsole(self, message):
+            logfile.Console(message)
+
+    #---------------------------------------------------------------------------
+    # R e a d R e q u e s t
+    #---------------------------------------------------------------------------
+    # Input:    characteristic for which the value is requested
+    #
+    # Function  Return the requested value, without further processing
+    #           Replaces parent class because of enhanced logging
+    #
+    # Output:   characteristic.value
+    #---------------------------------------------------------------------------
+    def ReadRequest(self,
+            characteristic: BlessGATTCharacteristic,
+            **kwargs
+            ) -> bytearray:
+
+        uuid  = str(characteristic._uuid)
+        if   uuid == bc.cFitnessMachineFeatureUUID:      char = bc.cFitnessMachineFeatureName
+        elif uuid == bc.cIndoorBikeDataUUID:             char = bc.cIndoorBikeDataName
+        elif uuid == bc.cFitnessMachineStatusUUID:       char = bc.cFitnessMachineStatusName
+        elif uuid == bc.cFitnessMachineControlPointUUID: char = bc.cFitnessMachineControlPointName
+        elif uuid == bc.cSupportedPowerRangeUUID:        char = bc.cSupportedPowerRangeName
+        elif uuid == bc.cHeartRateMeasurementUUID:       char = bc.cHeartRateMeasurementUUID
+        else:                                            char = "?"
+
+        #---------------------------------------------------------------------------
+        # Logging
+        #---------------------------------------------------------------------------
+        self.logfileWrite('clsFTMS_bless.ReadRequest(): characteristic "%s", value = %s' %
+                            (char, HexSpace(characteristic._value)))
+
+        return characteristic.value
+
+    #-------------------------------------------------------------------------------
+    # W r i t e R e q u e s t
+    #-------------------------------------------------------------------------------
+    # Input:    characteristic for which the value must be updated
+    #
+    # Function  Process the request
+    #
+    # Output:   characteristic values modified according request
+    #           HasControl, Started
+    #-------------------------------------------------------------------------------
+    def WriteRequest(self,
+            characteristic: BlessGATTCharacteristic,
+            pvalue: Any,
+            **kwargs
+            ):
+
+        value = bytes(pvalue)          # at least for struct.unpack()
+
+        uuid  = str(characteristic._uuid)
+        if   uuid == bc.cFitnessMachineFeatureUUID:      char = bc.cFitnessMachineFeatureName
+        elif uuid == bc.cIndoorBikeDataUUID:             char = bc.cIndoorBikeDataName
+        elif uuid == bc.cFitnessMachineStatusUUID:       char = bc.cFitnessMachineStatusName
+        elif uuid == bc.cFitnessMachineControlPointUUID: char = bc.cFitnessMachineControlPointName
+        elif uuid == bc.cSupportedPowerRangeUUID:        char = bc.cSupportedPowerRangeName
+        elif uuid == bc.cHeartRateMeasurementUUID:       char = bc.cHeartRateMeasurementUUID
+        else:                                            char = "?"
+        
+        #---------------------------------------------------------------------------
+        # Logging
+        #---------------------------------------------------------------------------
+        self.logfileWrite('bleBless: Write request for characteristic "%s", actual value = %s, provided value = %s' %
+                (char, HexSpace(characteristic.value), HexSpace(value)))
+
+        #---------------------------------------------------------------------------
+        # MachineControlPoint modifies behaviour; the only write we expect
+        #---------------------------------------------------------------------------
+        if not uuid == bc.cFitnessMachineControlPointUUID:
+            self.logfileConsole('bleBless error: Write request on "%s" characteristic is not supported; ignored.' % char)
+
+        else:
+            OpCode     = int(value[0])    # The operation to be performed
+            ResultCode = bc.fmcp_Success  # Let's assume it will be OK
+
+            UseWorkflow  = True           # A CTP must request control to be able to
+                                          # send further requests and Start before
+                                          # changing TargetPower/Grade
+                                          # If UseWorkflow == False, these checks
+                                          # are disabled.
+                                          #
+                                          # Funny things is, that HasControl suggests
+                                          # a check, but if the CTP proceeds regard-
+                                          # less, the Request would be accepted
+                                          # Unless there we would know what CTP has
+                                          # been granted access...
+                                          #
+                                          # Now that _FortiusAntServer() detects
+                                          # a disconnect, the workflow can be enabled.
+            #-----------------------------------------------------------------------
+            # React on requested operation
+            # - check workflow
+            # - accept values and/or modify internal state (HasControl, Started)
+            # - notify client that value is changed (FitnessMachineStatus)
+            # - notify that operation is completed (ResultCode)
+            #-----------------------------------------------------------------------
+            if OpCode == bc.fmcp_RequestControl:
+                if not UseWorkflow or not self.HasControl:
+                    self.HasControl = True
+                    self.Started    = False
+                    self.logfileWrite("bleBless: HasControl = True")
+                    self.Message   = ", Bluetooth interface controlled"
+                else:
+                    ResultCode = bc.fmcp_ControlNotPermitted
+                    self.logfileConsole("bleBless error: control requested by client, control already granted")
+
+            elif UseWorkflow and not self.HasControl:
+                ResultCode = bc.fmcp_ControlNotPermitted
+                self.logfileConsole("bleBless error: request received, but client has no control")
+
+            else:
+                if OpCode == bc.fmcp_StartOrResume:
+                    self.Started = True
+                    self.logfileWrite("bleBless: Started = True")
+                    self.notifyStartOrResume()              # Confirm receipt to client
+                    self.Message   = ", Bluetooth interface training started"
+
+                elif OpCode == bc.fmcp_SetTargetPower:
+                    try:
+                        tuple  = struct.unpack (bc.little_endian + bc.unsigned_char + bc.unsigned_short, value)
+                    except Exception as e:
+                        self.logfileConsole("bleBless error: unpack SetTargetPower %e" % e)
+                    #opcode          = tuple[0]
+                    self.TargetPower = tuple[1]
+                    self.TargetGrade = 0
+                    self.TargetMode  = mode_Power
+                    self.logfileWrite("bleBless: TargetPower = %s" % self.TargetPower)
+                    self.notifySetTargetPower()             # Confirm receipt to client
+                    self.Message   = ", Bluetooth interface in power mode"
+
+                elif OpCode == bc.fmcp_SetIndoorBikeSimulation:
+                    try:
+                        tuple  = struct.unpack (bc.little_endian + bc.unsigned_char + bc.short + bc.short + bc.unsigned_char + bc.unsigned_char, value)
+                    except Exception as e:
+                        self.logfileConsole("bleBless error: unpack SetIndoorBikeSimulation %s" % e)
+                    #opcode                = tuple[0]
+                    self.WindSpeed         = round(tuple[1] * 0.001,  3)
+                    self.TargetGrade       = round(tuple[2] * 0.01,   2)
+                    self.TargetPower       = 0
+                    self.TargetMode        = mode_Grade
+                    self.RollingResistance = round(tuple[3] * 0.0001, 4)
+                    self.WindResistance    = round(tuple[4] * 0.01,   2)
+                    self.logfileWrite(
+                           "bleBless: windspeed=%s, TargetGrade=%s, RollingResistance=%s, WindResistance=%s" %
+                           (self.WindSpeed, self.TargetGrade, self.RollingResistance, self.WindResistance))
+                    self.notifySetIndoorBikeSimulation()    # Confirm receipt to client
+                    self.Message   = ", Bluetooth interface in grade mode"
+
+                elif OpCode == bc.fmcp_StopOrPause:
+                    self.Started = False
+                    self.logfileWrite("bleBless: Started = False")
+                    self.notifyStopOrPause()                # Confirm receipt to client
+                    self.Message   = ", Bluetooth interface training stopped"
+
+                elif OpCode == bc.fmcp_Reset:
+                    self.Started    = False
+                    self.HasControl = False
+                    self.logfileWrite("bleBless: HasControl = False")
+                    self.notifyReset()                      # Confirm receipt to client
+                    self.Message   = ", Bluetooth interface open"
+
+                else:
+                    self.logfileConsole("bleBless error: Unknown OpCode %s" % OpCode)
+                    ResultCode = bc.fmcp_ControlNotPermitted
+
+            #-----------------------------------------------------------------------
+            # Response:
+            #-----------------------------------------------------------------------
+            ResponseCode = 0x80
+            info = struct.pack(bc.little_endian + bc.unsigned_char * 3, ResponseCode, OpCode, ResultCode)
+            characteristic.value = info
+            self.BlessServer.update_value(bc.sFitnessMachineUUID, bc.cFitnessMachineControlPointUUID)
+
+            if False:
+                self.logfileWrite("bleBless: New value for characteristic %s = %s" % (char, HexSpace(info)))
+
+    # --------------------------------------------------------------------------
+    # After that a characteristic is written, it must also be confirmed through
+    # a notification in FitnessMachineStatus
+    # --------------------------------------------------------------------------
+    def notifyStartOrResume(self):
+        self.logfileWrite("bleBless.notifyStartOrResume()")
+        info = struct.pack(bc.little_endian + bc.unsigned_char, bc.fms_FitnessMachineStartedOrResumedByUser)
+        self.BlessServer.get_characteristic(bc.cFitnessMachineStatusUUID).value = info
+        self.BlessServer.update_value(bc.sFitnessMachineUUID, bc.cFitnessMachineStatusUUID)
+
+    def notifySetTargetPower(self):
+        self.logfileWrite("bleBless.notifySetTargetPower()")
+        info = struct.pack(bc.little_endian + bc.unsigned_char + bc.unsigned_short, bc.fms_TargetPowerChanged, self.TargetPower)
+        self.BlessServer.get_characteristic(bc.cFitnessMachineStatusUUID).value = info
+        self.BlessServer.update_value(bc.sFitnessMachineUUID, bc.cFitnessMachineStatusUUID)
+
+    def notifySetIndoorBikeSimulation(self):
+        self.logfileWrite("bleBless.notifySetIndoorBikeSimulation()")
+
+        windSpeed = int(self.WindSpeed         / 0.001 )
+        grade     = int(self.TargetGrade       / 0.01  )
+        crr       = int(self.RollingResistance / 0.0001)
+        cw        = int(self.WindResistance    / 0.01  )
+
+        info = struct.pack(bc.little_endian + bc.unsigned_char + bc.short * 2 + bc.unsigned_char * 2,
+                            bc.fms_IndoorBikeSimulationParametersChanged, windSpeed, grade, crr, cw)
+        self.BlessServer.get_characteristic(bc.cFitnessMachineStatusUUID).value = info
+        self.BlessServer.update_value(bc.sFitnessMachineUUID, bc.cFitnessMachineStatusUUID)
+
+    def notifyStopOrPause(self):
+        self.logfileWrite("bleBless.notifyStopOrPause()")
+        info = struct.pack(bc.little_endian + bc.unsigned_char, bc.fms_FitnessMachineStoppedOrPausedByUser)
+        self.BlessServer.get_characteristic(bc.cFitnessMachineStatusUUID).value = info
+        self.BlessServer.update_value(bc.sFitnessMachineUUID, bc.cFitnessMachineStatusUUID)
+
+    def notifyReset(self):
+        self.logfileWrite("bleBless.notifyReset()")
+        info = struct.pack(bc.little_endian + bc.unsigned_char, bc.fms_Reset)
+        self.BlessServer.get_characteristic(bc.cFitnessMachineStatusUUID).value = info
+        self.BlessServer.update_value(bc.sFitnessMachineUUID, bc.cFitnessMachineStatusUUID)
+
+    # ------------------------------------------------------------------------------
+    # S i m u l a t o r
+    # ------------------------------------------------------------------------------
+    # Input     None
+    #
+    # Function  For test-purpose, simulate a trainer with random data.
+    #           A real application will have a similar structure:
+    #           while True:
+    #               time-control
+    #               SetAthleteData() and/or SetTrainerData()
+    #               Refresh()
+    #               use class-attributes (TargetMode, TargetPower, ...)
+    #               
+    #
+    # Output    The interface is used, no further output.
+    # ------------------------------------------------------------------------------
+    def Simulator(self):
+        self.logfileConsole("---------------------------------------------------------------------------------------")
+        self.logfileConsole("FortiusAnt simulated trainer is active")
+        self.logfileConsole("Start a training in a CTP; 5 seconds after completing the training, simulation will end")
+        self.logfileConsole("---------------------------------------------------------------------------------------")
+
+        #---------------------------------------------------------------------------
+        # FortiusAntServer is now active
+        # read/write through read_Request() and write_Request() functions
+        #---------------------------------------------------------------------------
+        ClientWasConnected = False
+        i = 5
+        while i:
+            #-----------------------------------------------------------------------
+            # Stop 5 seconds after a client is disconnected
+            # In the meantime, Start, Power/Grade, Stop is expected....
+            #-----------------------------------------------------------------------
+            if self.ClientConnected:
+                ClientWasConnected = True
+
+            if ClientWasConnected and not self.ClientConnected:
+                i -= 1
+                pass
+
+            #-----------------------------------------------------------------------
+            # Update trainer info every second
+            #-----------------------------------------------------------------------
+            time.sleep(1)
+
+            #-----------------------------------------------------------------------
+            # Create some fancy data
+            #-----------------------------------------------------------------------
+            s = int(time.time() % 60)           # Seconds
+            HeartRate   =   int(000 + s)
+            Cadence     =   int(100 + s )
+            CurrentSpeed= round(200 + s,1)
+            CurrentPower=   int(300 + s)
+
+            #-----------------------------------------------------------------------
+            # Update actual values of Athlete and Trainer
+            #-----------------------------------------------------------------------
+            self.SetAthleteData(HeartRate)
+            self.SetTrainerData(CurrentSpeed, Cadence, CurrentPower)
+
+            #-----------------------------------------------------------------------
+            # Allow class to take care that attributes are accurate
+            #-----------------------------------------------------------------------
+            self.Refresh()
+
+            #-----------------------------------------------------------------------
+            # Here the real application can take action, usually adjust the
+            # resistance of the bicycle and/or display the target Mode/Power/Grade.
+            #-----------------------------------------------------------------------
+
+            #-----------------------------------------------------------------------
+            # All we do is show current status / target
+            # --> Four variables are filled by ourselves, which in reality comes from
+            #     the athlete's HeartRateMonitor and the fitness bike (see above).
+            #
+            # --> HasControl and Started are status fields from the class
+            #
+            # --> TargetMode, TargetPower, TargetGrade are provided by the Cycling
+            #       Trining Program (CTP), the client to this fitness machine.
+            #-----------------------------------------------------------------------
+            print(
+                "Client=%-5s HasControl=%-5s Started=%-5s TargetPower=%4s TargetGrade=%-6s Speed=%3s Cadence=%3s, Power=%3s, HeartRate=%3s" %
+                (self.ClientConnected, self.HasControl, self.Started, self.TargetPower, self.TargetGrade, self.CurrentSpeed, self.Cadence, self.CurrentPower, self.HeartRate))
+
+        self.logfileConsole("FortiusAnt simulated trainer is stopped")
+        self.logfileConsole("---------------------------------------")
+
+# ==============================================================================
+# Main program
+# ==============================================================================
+if __name__ == "__main__":
+    #---------------------------------------------------------------------------
+    # Initialization
+    #---------------------------------------------------------------------------
+    if not BlessExample:
+        debug.activate(debug.Ble | debug.logging_DEBUG)
+        logfile.Open()
+        print('FTMS server in FortiusAnt context')
+    else:
+        logging.basicConfig(level=logging.ERROR)
+        logger = logging.getLogger(name=__name__)
+        print('FTMS server in bless/example context')
+
+    print("bleBless started")
+    print("----------------")
+
+    #---------------------------------------------------------------------------
+    # This is what it's all about
+    #---------------------------------------------------------------------------
+    FortiusAntServer = clsFTMS_bless(True)              # clv.ble
+    print("Message=%s" % FortiusAntServer.Message)
+
+    b = FortiusAntServer.Open()
+    print("Message=%s" % FortiusAntServer.Message)
+
+    if b:
+        FortiusAntServer.Simulator()
+        FortiusAntServer.Close()
+        print("Message=%s" % FortiusAntServer.Message)
+
+    #---------------------------------------------------------------------------
+    # Termination
+    #---------------------------------------------------------------------------
+    print("bleBless ended")

--- a/examples/FTMSserver.py
+++ b/examples/FTMSserver.py
@@ -14,7 +14,8 @@
 #-------------------------------------------------------------------------------
 # Version info
 #-------------------------------------------------------------------------------
-__version__ = "2022-03-08"
+__version__ = "2022-03-21"
+# 2022-03-21    Made available to kevincar/bless as example; small modifications
 # 2022-03-08    Class to create a bless server split into bleBlessClass.py
 # 2022-03-08    Tested:
 #               - Windows 10 with Trainer Road and Rouvy
@@ -39,15 +40,8 @@ from bless import (
         GATTAttributePermissions
         )
 
-#-------------------------------------------------------------------------------
-# To distribute to bless/examples, proceed as follows:
-# - Copy bleBless.py, bleBlessClass and bleConstants   bleBleak.py to hbldh\bless\examples
-#        FTMSserver   FTMSserverClass   FTMSconstants  FTMSclient
-# - Change BlessExample to True
-# - Check code for BlessExample
-#-------------------------------------------------------------------------------
-BlessExample = True
-if not BlessExample:
+if False:
+    BlessExample = False
     #---------------------------------------------------------------------------
     # Import in the FortiusAnt context
     #---------------------------------------------------------------------------
@@ -58,20 +52,19 @@ if not BlessExample:
     from   bleBlessClass        import clsBleServer
     import bleConstants         as bc
 
-if BlessExample:
+else:
+    BlessExample = True
     #---------------------------------------------------------------------------
     # Import and Constants for bless example context
     #---------------------------------------------------------------------------
     from   FTMSserverClass      import clsBleServer
     import FTMSconstants        as bc
-
+    from   FTMSconstants        import HexSpace
     import logging
+
     mode_Power          = 1     # Target Power
     mode_Grade          = 2     # Target Resistance
     UseBluetooth        = True
-
-    def HexSpace(info):
-        return (info)
 
 #-------------------------------------------------------------------------------
 # Define the server structure with services and characteristics
@@ -698,7 +691,7 @@ if __name__ == "__main__":
         logfile.Open()
         print('FTMS server in FortiusAnt context')
     else:
-        logging.basicConfig(level=logging.ERROR)
+        logging.basicConfig(level=logging.ERROR)            # pylint:disable=invalid-name,used-before-assignment,undefined-variable
         logger = logging.getLogger(name=__name__)
         print('FTMS server in bless/example context')
 
@@ -723,3 +716,58 @@ if __name__ == "__main__":
     # Termination
     #---------------------------------------------------------------------------
     print("bleBless ended")
+
+"""
+SAMPLE OUTPUT:
+==============
+
+bleBless started
+----------------
+Message=, Bluetooth interface available (bless)
+Message=, Bluetooth interface open
+20:03:56,328: ---------------------------------------------------------------------------------------
+20:03:56,329: FortiusAnt simulated trainer is active
+20:03:56,329: Start a training in a CTP; 5 seconds after completing the training, simulation will end
+20:03:56,330: ---------------------------------------------------------------------------------------
+Client=False HasControl=False Started=False TargetPower= 100 TargetGrade=0      Speed=257 Cadence=157, Power=357, HeartRate= 57
+Client=False HasControl=False Started=False TargetPower= 100 TargetGrade=0      Speed=258 Cadence=158, Power=358, HeartRate= 58
+Client=False HasControl=False Started=False TargetPower= 100 TargetGrade=0      Speed=259 Cadence=159, Power=359, HeartRate= 59
+Client=False HasControl=False Started=False TargetPower= 100 TargetGrade=0      Speed=200 Cadence=100, Power=300, HeartRate=  0
+Client=False HasControl=False Started=False TargetPower= 100 TargetGrade=0      Speed=201 Cadence=101, Power=301, HeartRate=  1
+Client=False HasControl=False Started=False TargetPower= 100 TargetGrade=0      Speed=202 Cadence=102, Power=302, HeartRate=  2
+Client=False HasControl=False Started=False TargetPower= 100 TargetGrade=0      Speed=203 Cadence=103, Power=303, HeartRate=  3
+Client=False HasControl=False Started=False TargetPower= 100 TargetGrade=0      Speed=204 Cadence=104, Power=304, HeartRate=  4
+Client=False HasControl=False Started=False TargetPower= 100 TargetGrade=0      Speed=205 Cadence=105, Power=305, HeartRate=  5
+Client=False HasControl=False Started=False TargetPower= 100 TargetGrade=0      Speed=206 Cadence=106, Power=306, HeartRate=  6
+Client=False HasControl=False Started=False TargetPower= 100 TargetGrade=0      Speed=207 Cadence=107, Power=307, HeartRate=  7
+Client=False HasControl=False Started=False TargetPower= 100 TargetGrade=0      Speed=208 Cadence=108, Power=308, HeartRate=  8
+Client=False HasControl=False Started=False TargetPower= 100 TargetGrade=0      Speed=209 Cadence=109, Power=309, HeartRate=  9
+Client=False HasControl=False Started=False TargetPower= 100 TargetGrade=0      Speed=210 Cadence=110, Power=310, HeartRate= 10
+Client=False HasControl=False Started=False TargetPower= 100 TargetGrade=0      Speed=211 Cadence=111, Power=311, HeartRate= 11
+Client=False HasControl=False Started=False TargetPower= 100 TargetGrade=0      Speed=212 Cadence=112, Power=312, HeartRate= 12
+Client=False HasControl=False Started=False TargetPower= 100 TargetGrade=0      Speed=213 Cadence=113, Power=313, HeartRate= 13
+Client=False HasControl=False Started=False TargetPower= 100 TargetGrade=0      Speed=214 Cadence=114, Power=314, HeartRate= 14
+Client=True  HasControl=True  Started=False TargetPower= 100 TargetGrade=0      Speed=215 Cadence=115, Power=315, HeartRate= 15
+Client=True  HasControl=True  Started=True  TargetPower= 100 TargetGrade=0      Speed=216 Cadence=116, Power=316, HeartRate= 16
+Client=True  HasControl=True  Started=True  TargetPower= 324 TargetGrade=0      Speed=217 Cadence=117, Power=317, HeartRate= 17
+Client=True  HasControl=True  Started=True  TargetPower=   0 TargetGrade=4.0    Speed=218 Cadence=118, Power=318, HeartRate= 18
+Client=True  HasControl=True  Started=True  TargetPower= 323 TargetGrade=0      Speed=219 Cadence=119, Power=319, HeartRate= 19
+Client=True  HasControl=True  Started=True  TargetPower=   0 TargetGrade=3.0    Speed=220 Cadence=120, Power=320, HeartRate= 20
+Client=True  HasControl=True  Started=True  TargetPower= 322 TargetGrade=0      Speed=221 Cadence=121, Power=321, HeartRate= 21
+Client=True  HasControl=True  Started=True  TargetPower=   0 TargetGrade=2.0    Speed=222 Cadence=122, Power=322, HeartRate= 22
+Client=True  HasControl=True  Started=True  TargetPower=   0 TargetGrade=2.0    Speed=223 Cadence=123, Power=323, HeartRate= 23
+Client=True  HasControl=True  Started=True  TargetPower= 321 TargetGrade=0      Speed=224 Cadence=124, Power=324, HeartRate= 24
+Client=True  HasControl=True  Started=True  TargetPower=   0 TargetGrade=1.0    Speed=225 Cadence=125, Power=325, HeartRate= 25
+Client=True  HasControl=True  Started=True  TargetPower=  50 TargetGrade=0      Speed=226 Cadence=126, Power=326, HeartRate= 26
+Client=True  HasControl=True  Started=False TargetPower=  50 TargetGrade=0      Speed=227 Cadence=127, Power=327, HeartRate= 27
+Client=True  HasControl=False Started=False TargetPower=  50 TargetGrade=0      Speed=228 Cadence=128, Power=328, HeartRate= 28
+Client=True  HasControl=False Started=False TargetPower=  50 TargetGrade=0      Speed=229 Cadence=129, Power=329, HeartRate= 29
+Client=False HasControl=False Started=False TargetPower=  50 TargetGrade=0      Speed=230 Cadence=130, Power=330, HeartRate= 30
+Client=False HasControl=False Started=False TargetPower=  50 TargetGrade=0      Speed=231 Cadence=131, Power=331, HeartRate= 31
+Client=False HasControl=False Started=False TargetPower=  50 TargetGrade=0      Speed=232 Cadence=132, Power=332, HeartRate= 32
+Client=False HasControl=False Started=False TargetPower=  50 TargetGrade=0      Speed=233 Cadence=133, Power=333, HeartRate= 33
+Client=False HasControl=False Started=False TargetPower=  50 TargetGrade=0      Speed=234 Cadence=134, Power=334, HeartRate= 34
+Client=False HasControl=False Started=False TargetPower=  50 TargetGrade=0      Speed=235 Cadence=135, Power=335, HeartRate= 35
+20:04:35,810: FortiusAnt simulated trainer is stopped
+20:04:35,812: ---------------------------------------
+"""

--- a/examples/FTMSserverClass.py
+++ b/examples/FTMSserverClass.py
@@ -1,0 +1,338 @@
+#-------------------------------------------------------------------------------
+# Author        https://github.com/WouterJD
+#               wouter.dubbeldam@xs4all.nl
+#-------------------------------------------------------------------------------
+# Version info
+#-------------------------------------------------------------------------------
+__version__ = "2022-03-15"
+# 2022-03-15    This implementation works, Windows10 and Raspberry
+#               One open issue: How to set the Generic Access Profile
+#                   characteristics, such as DeviceName and Appearance.
+#               See: https://github.com/kevincar/bless/issues/75
+# 2022-03-08    Class to create a bless server
+# 2020-12-18    First version, obtained from: " hbldh\bless"
+#               inspired by examples\gattserver.py
+#               Example for a BLE 4.0 Server using a GATT dictionary of
+#               characteristics
+#-------------------------------------------------------------------------------
+import asyncio
+import atexit
+import logging
+from   socket               import timeout
+import time
+import threading
+
+from typing import Any, Dict
+
+from bless import (
+        BlessServer,
+        BlessGATTCharacteristic,
+        GATTCharacteristicProperties,
+        GATTAttributePermissions
+        )
+
+#-------------------------------------------------------------------------------
+# c l s B l e S e r v e r
+#-------------------------------------------------------------------------------
+# Class to create a BLE server, using bless
+#
+# User methods:
+#   __init__()      When the instance is created, the data structure is made
+#                   but no functions yet executed. Open()/Close() to be used.
+#   Open()          Creates the FTMS server
+#   Close()         Closes the FTMS server
+#
+#   ClientDisconnected()
+#                   Is called when a client disconnects, so that the child-class
+#                   can act accordingly
+#
+#   ReadRequest()   Can be overwritten by child-class if so desired
+#   WriteRequest()  Should be implemented by child-class to make the server work
+#
+# User attributes:
+#   Message         User message to indicate status of the BLE server
+#   ClientConnected Boolean, indicating that a client is connected
+#   BlessServer     to be used in child-class to access characteristics
+#
+# Yes indeed, this class is not of much use for an application yet, the child
+# must implement the real functionality.
+#-------------------------------------------------------------------------------
+class clsBleServer:
+    #---------------------------------------------------------------------------
+    # External attributes
+    #---------------------------------------------------------------------------
+    Message             = ''            # Shows status of interface
+
+    #---------------------------------------------------------------------------
+    # Internal processing data
+    #---------------------------------------------------------------------------
+    OK                  = False         # FTMS is operational
+    BlessServer         = None          # The BlessServer instance
+    loop                = None          # Loop instance to support BlessServer
+    ClientConnected     = False         # copy of BlessServer.is_connected()
+    ClientWasConnected  = False
+
+    myServiceName       = "NoNameService"   # Provided on creation
+    myGattDefinition    = "<not provided>"
+
+    # --------------------------------------------------------------------------
+    # _ _ i n i t _ _
+    # --------------------------------------------------------------------------
+    # Input     myServiceName, myGattDefinition
+    #
+    # Function  Create the instance,
+    #           note thatFTMS starting is done through Open().
+    #
+    # Output    .Message, .myServiceName, .myGattDefinition
+    # --------------------------------------------------------------------------
+    def __init__(self, myServiceName, myGattDefinition):
+        self.Message            = ", Bluetooth interface available (bless)"
+        self.myServiceName      = myServiceName
+        self.myGattDefinition   = myGattDefinition
+        #-----------------------------------------------------------------------
+        # register self.Close() to make sure the BLE server is stopped
+        #   ON program termination
+        # Note that __del__ is called too late to be able to close.
+        #-----------------------------------------------------------------------
+        atexit.register(self.Close)
+
+    # --------------------------------------------------------------------------
+    # O p e n
+    # --------------------------------------------------------------------------
+    # Input     None
+    #
+    # Function  In a separate thread;
+    #               Create a loop and then activate FortiusAntServer
+    #
+    # Output    OK = True
+    #
+    # Returns   self.OK
+    # --------------------------------------------------------------------------
+    def Open(self):
+        #-----------------------------------------------------------------------
+        # Logging
+        #-----------------------------------------------------------------------
+        self.logfileWrite("clsBleServer.Open()")
+
+        #-----------------------------------------------------------------------
+        # Create a thread and run the server in that thread
+        #-----------------------------------------------------------------------
+        thread = threading.Thread(target=self._OpenThread)
+        thread.start()
+
+        #-----------------------------------------------------------------------
+        # Allow thread to start
+        #-----------------------------------------------------------------------
+        time.sleep(1)
+
+        #-----------------------------------------------------------------------
+        # After a second, the thread will be initiated and self.OK = True
+        # (For the time being, at least)
+        #-----------------------------------------------------------------------
+        return self.OK
+
+    def _OpenThread(self):
+        self.OK      = True
+        self.Message = ", Bluetooth interface open" # Assume it will work OK
+
+        #loop = asyncio.get_event_loop()            # Crashes: "There is no current event loop in thread"
+        self.loop    = asyncio.new_event_loop()     # Because we're in a thread
+        self.loop.run_until_complete(self._Server())
+        self.loop    = None
+
+    # --------------------------------------------------------------------------
+    # _ S e r v e r
+    # --------------------------------------------------------------------------
+    # Input     .myServiceName
+    #           .myGattDefinition
+    #           .OK
+    #           .loop
+    #
+    # Function  A BLE-server is created with the required services and characteristics
+    #           The server will remain active until Close() is called
+    #
+    # Output    BLE Server/Service/Characteristics
+    # --------------------------------------------------------------------------
+    async def _Server(self):
+        #-----------------------------------------------------------------------
+        # Create the server
+        #-----------------------------------------------------------------------
+        self.logfileWrite("clsBleServer._Server(%s)" % self.myServiceName)
+
+        if self.OK:
+            self.BlessServer = BlessServer(name=self.myServiceName, loop=self.loop)
+            
+            self.BlessServer.read_request_func  = self.ReadRequest
+            self.BlessServer.write_request_func = self.WriteRequest
+
+        #-----------------------------------------------------------------------
+        # Add the gatt-services and start
+        # Note:
+        # Windows 10: BLE crashes on add_gatt() if there is no BLE-5 dongle
+        #             BLE crashes on start()    if interface is not compatible
+        #-----------------------------------------------------------------------
+        self.logfileWrite("clsBleServer._Server(): self.BlessServer.add_gatt()")
+        if self.OK:
+            try:
+                await self.BlessServer.add_gatt(self.myGattDefinition)
+            except Exception as e:
+                self.OK = False
+                self.logfileConsole("clsBleServer._Server(); add_gatt() exception %s" % e)
+
+        self.logfileWrite("clsBleServer._Server(): self.BlessServer.start()")
+        if self.OK:
+            try:
+                await self.BlessServer.start()
+            except Exception as e:
+                self.OK = False
+                self.logfileConsole("clsBleServer._Server(); start() exception %s" % e)
+
+        if not self.OK:
+            self.Message = ", Bluetooth interface n/a; BLE-5 required!"
+            self.logfileConsole(self.Message)
+
+        #-----------------------------------------------------------------------
+        # Server is now active
+        # read/write through ReadRequest() and WriteRequest() functions
+        # Server will stop when OK = False.
+        #-----------------------------------------------------------------------
+        self.logfileWrite("clsBleServer._Server(): 1 second loop untill Close() called")
+        WeWereOK = self.OK
+        while self.OK:
+            await asyncio.sleep(1)
+            #-------------------------------------------------------------------
+            # Check whether there are clients connected
+            # If a client disconnects, notify the subclass, perhaps action must
+            #       be taken.
+            # There is no reason to stop, simply keep active untill the next
+            #       client connects.
+            #-------------------------------------------------------------------
+            self.ClientConnected = await self.BlessServer.is_connected()
+                               # = len(self.BlessServer._subscribed_clients) > 0
+
+            if not self.ClientConnected and self.ClientWasConnected:
+                self.ClientDisconnected()
+                self.logfileWrite(
+                    "clsBleServer._Server: A client was active and is disconnected.")
+
+            self.ClientWasConnected = self.ClientConnected
+
+        #-----------------------------------------------------------------------
+        # Cleanup
+        # self.OK is always False, since set by Close()!!
+        #-----------------------------------------------------------------------
+        if WeWereOK:
+            self.logfileWrite("clsBleServer._Server(): self.BlessServer.stop()")
+            await self.BlessServer.stop()
+
+        #-----------------------------------------------------------------------
+        # Logging
+        #-----------------------------------------------------------------------
+        self.logfileWrite("clsBleServer._Server() ended")
+
+    # --------------------------------------------------------------------------
+    # C l i e n t D i s c o n n e c t e d
+    # --------------------------------------------------------------------------
+    # Input     None
+    #
+    # Function  A disconnect is detected, one may use this to react accordingly
+    #
+    # Output    None
+    # --------------------------------------------------------------------------
+    def ClientDisconnected(self):
+        pass
+
+    # --------------------------------------------------------------------------
+    # C l o s e
+    # --------------------------------------------------------------------------
+    # Input     None
+    #
+    # Function  Indicate that FortiusAntServer() must stop
+    #
+    # Output    OK = False
+    # --------------------------------------------------------------------------
+    def Close(self):
+        #-----------------------------------------------------------------------
+        # Logging
+        #-----------------------------------------------------------------------
+        self.logfileWrite("clsBleServer.Close()")
+
+        #-----------------------------------------------------------------------
+        # Signal FortiusAntServer to stop
+        #-----------------------------------------------------------------------
+        self.Message = ", Bluetooth interface closed"
+        self.OK      = False
+
+        #-----------------------------------------------------------------------
+        # Allow thread to close
+        #-----------------------------------------------------------------------
+        time.sleep(2)
+
+    #---------------------------------------------------------------------------
+    # L o g f i l e W r i t e / C o n s o l e
+    #---------------------------------------------------------------------------
+    # Input:    message to be written to logfile
+    #
+    # Function  Use python logging functions
+    #
+    # Output:   none
+    #---------------------------------------------------------------------------
+    def logfileWrite(self, message):
+        logging.info(message)
+
+    def logfileConsole(self, message):
+        logging.error(message)
+
+    #---------------------------------------------------------------------------
+    # R e a d R e q u e s t
+    #---------------------------------------------------------------------------
+    # Input:    characteristic for which the value is requested
+    #
+    # Function  Return the requested value, without further processing
+    #
+    # Output:   characteristic.value
+    #---------------------------------------------------------------------------
+    def ReadRequest(self,
+            characteristic: BlessGATTCharacteristic,
+            **kwargs
+            ) -> bytearray:
+
+        uuid  = str(characteristic._uuid)
+
+        #---------------------------------------------------------------------------
+        # Logging
+        #---------------------------------------------------------------------------
+        self.logfileWrite('clsBleServer.ReadRequest(): characteristic uuid="%s", value = %s' %
+                            (uuid, characteristic._value))
+
+        return characteristic.value
+
+    #-------------------------------------------------------------------------------
+    # W r i t e R e q u e s t
+    #-------------------------------------------------------------------------------
+    # Input:    characteristic for which the value must be updated
+    #
+    # Function  Check what characteristic must be changed and act accordingly
+    #
+    # Output:   To be defined by child class.
+    #-------------------------------------------------------------------------------
+    def WriteRequest(self,
+            characteristic: BlessGATTCharacteristic,
+            value: Any,
+            **kwargs
+            ):
+
+        uuid  = str(characteristic._uuid)
+        
+        #---------------------------------------------------------------------------
+        # Logging
+        #---------------------------------------------------------------------------
+        self.logfileWrite('clsBleServer.WriteRequest(): characteristic "%s", actual value = %s, provided value = %s' %
+                (uuid, characteristic.value, value))
+        self.logfileConsole('clsBleServer.WriteRequest() error: Not implemented!')
+
+# ==============================================================================
+# Main program
+# ==============================================================================
+if __name__ == "__main__":
+    print("bleBlessClient.py cannot be executed on it's own.")

--- a/examples/Test FTMSclient.bat
+++ b/examples/Test FTMSclient.bat
@@ -1,0 +1,2 @@
+FTMSclient.py
+pause

--- a/examples/Test FTMSserver.bat
+++ b/examples/Test FTMSserver.bat
@@ -1,0 +1,2 @@
+FTMSserver.py
+pause


### PR DESCRIPTION
FTMSserver creates a bless server with a FTMS profile
FTMSclient inspects what ble-devices are present, searches for FTMS server and prints the service/characteristics structure

FTMSserver is inspired by bless/examples/gattserver.py
FTMSclient is inspired by bleak/examples/discover.py and service_explorer.py

First start FTMSserver, then FTSMclient.

See [QUESTION: How to define the Generic Access Profile (during BlessServer creation)?](https://github.com/kevincar/bless/discussions/76)