### PR TITLE
60 dbus next

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,7 +18,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macos-latest
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/bless/backends/bluezdbus/characteristic.py
+++ b/bless/backends/bluezdbus/characteristic.py
@@ -65,7 +65,7 @@ class BlessGATTCharacteristicBlueZDBus(
 
         # Add to our BlueZDBus app
         gatt_char: BlueZGattCharacteristic = await service.gatt.add_characteristic(
-            self._uuid, flags, self.value
+            self._uuid, flags, bytes(self.value)
         )
         dict_obj: Dict = await gatt_char.get_obj()
 
@@ -84,6 +84,11 @@ class BlessGATTCharacteristicBlueZDBus(
     def value(self, val: bytearray):
         """Set the value of the characteristic"""
         self._value = val
+
+    @property
+    def uuid(self) -> str:
+        """The uuid of this characteristic"""
+        return self.obj.get("UUID").value
 
 
 def flags_to_dbus(flags: GATTCharacteristicProperties) -> List[Flags]:

--- a/bless/backends/bluezdbus/dbus/advertisement.py
+++ b/bless/backends/bluezdbus/dbus/advertisement.py
@@ -2,7 +2,7 @@ from enum import Enum
 
 from typing import List, Dict, TYPE_CHECKING
 
-from dbus_next.service import ServiceInterface, method, dbus_property
+from dbus_next.service import ServiceInterface, method, dbus_property  # type: ignore
 
 if TYPE_CHECKING:
     from bless.backends.bluezdbus.dbus.application import (  # type: ignore

--- a/bless/backends/bluezdbus/dbus/advertisement.py
+++ b/bless/backends/bluezdbus/dbus/advertisement.py
@@ -2,8 +2,7 @@ from enum import Enum
 
 from typing import List, Dict, TYPE_CHECKING
 
-from txdbus.objects import DBusObject, DBusProperty, dbusMethod  # type: ignore
-from txdbus.interface import DBusInterface, Method, Property  # type: ignore
+from dbus_next.service import ServiceInterface, method, dbus_property
 
 if TYPE_CHECKING:
     from bless.backends.bluezdbus.dbus.application import (  # type: ignore
@@ -16,32 +15,12 @@ class Type(Enum):
     PERIPHERAL = "peripheral"
 
 
-class BlueZLEAdvertisement(DBusObject):
+class BlueZLEAdvertisement(ServiceInterface):
     """
     org.bluez.LEAdvertisement1 interface implementation
     """
 
     interface_name: str = "org.bluez.LEAdvertisement1"
-
-    iface: DBusInterface = DBusInterface(
-        interface_name,
-        Method("Release"),
-        Property("Type", "s"),
-        Property("ServiceUUIDs", "as"),
-        Property("ManufacturerData", "a{qay}"),
-        Property("SolicitUUIDs", "as"),
-        Property("ServiceData", "a{sv}"),
-        Property("IncludeTxPower", "b"),
-    )
-
-    dbusInterfaces: List[DBusInterface] = [iface]
-
-    ad_type: DBusProperty = DBusProperty("Type")
-    service_uuids: DBusProperty = DBusProperty("ServiceUUIDs")
-    # manufacturer_data = DBusProperty("ManufacturerData")
-    # solicit_uuids = DBusProperty("SolicitUUIDs")
-    # service_data = DBusProperty("ServiceData")
-    include_tx_power: DBusProperty = DBusProperty("IncludeTxPower")
 
     def __init__(
         self,
@@ -61,19 +40,67 @@ class BlueZLEAdvertisement(DBusObject):
         app : BlueZGattApplication
             The Application that is responsible for this advertisement
         """
-        self.ad_type: str = advertising_type.value
         self.path = app.base_path + "/advertisement" + str(index)
 
-        self.service_uuids: List[str] = []
-        self.manufacturer_data: Dict = {}
-        self.solicit_uuids = [""]
-        self.service_data = {"": 0}
+        self._type: str = advertising_type.value
+        self._service_uuids: List[str] = []
+        self._manufacturer_data: Dict = {}
+        self._solicit_uuids: List[str] = [""]
+        self._service_data: Dict = {}
 
-        self.include_tx_power: bool = False
+        self._include_tx_power: bool = False
 
         self.data = None
-        super(BlueZLEAdvertisement, self).__init__(self.path)
+        super(BlueZLEAdvertisement, self).__init__(self.interface_name)
 
-    @dbusMethod(interface_name, "Release")
+    @method()
     def Release(self):  # noqa: N802
         print("%s: Released!" % self.path)
+
+    @dbus_property()
+    def Type(self) -> "s":  # type: ignore # noqa: F821
+        return self._type
+
+    @Type.setter  # type: ignore
+    def Type(self, type: "s"):  # type: ignore # noqa: F821 F722
+        self._type = type
+
+    @dbus_property()
+    def ServiceUUIDs(self) -> "as":  # type: ignore # noqa: F821 F722
+        return self._service_uuids
+
+    @ServiceUUIDs.setter  # type: ignore
+    def ServiceUUIDs(self, service_uuids: "as"):  # type: ignore # noqa: F821 F722
+        self._service_uuids = service_uuids
+
+    @dbus_property()
+    def ManufacturerData(self) -> "a{qv}":  # type: ignore # noqa: F821 F722
+        return self._manufacturer_data
+
+    @ManufacturerData.setter  # type: ignore
+    def ManufacturerData(self, data: "a{qv}"):  # type: ignore # noqa: F821 F722
+        self._manufacturer_data = data
+
+    # @dbus_property()
+    # def SolicitUUIDs(self) -> "as":  # type: ignore # noqa: F821 F722
+        # return self._solicit_uuids
+
+    # @SolicitUUIDs.setter  # type: ignore
+    # def SolicitUUIDs(self, uuids: "as"):  # type: ignore # noqa: F821 F722
+        # self._solicit_uuids = uuids
+
+    @dbus_property()
+    def ServiceData(self) -> "a{sv}":  # type: ignore # noqa: F821 F722
+        return self._service_data
+
+    @ServiceData.setter  # type: ignore
+    def ServiceData(self, data: "a{sv}"):  # type: ignore # noqa: F821 F722
+        self._service_data = data
+
+    @dbus_property()
+    def IncludeTxPower(self) -> "b":  # type: ignore # noqa: F821
+        return self._include_tx_power
+
+    @IncludeTxPower.setter  # type: ignore
+    def IncludeTxPower(self, include: "b"):  # type: ignore # noqa: F821
+        self._include_tx_power = include

--- a/bless/backends/bluezdbus/dbus/advertisement.py
+++ b/bless/backends/bluezdbus/dbus/advertisement.py
@@ -65,19 +65,19 @@ class BlueZLEAdvertisement(ServiceInterface):
     def Type(self, type: "s"):  # type: ignore # noqa: F821 F722
         self._type = type
 
-    @dbus_property()
+    @dbus_property()  # noqa: F722
     def ServiceUUIDs(self) -> "as":  # type: ignore # noqa: F821 F722
         return self._service_uuids
 
-    @ServiceUUIDs.setter  # type: ignore
+    @ServiceUUIDs.setter  # type: ignore # noqa: 722
     def ServiceUUIDs(self, service_uuids: "as"):  # type: ignore # noqa: F821 F722
         self._service_uuids = service_uuids
 
-    @dbus_property()
+    @dbus_property()  # noqa: 722
     def ManufacturerData(self) -> "a{qv}":  # type: ignore # noqa: F821 F722
         return self._manufacturer_data
 
-    @ManufacturerData.setter  # type: ignore
+    @ManufacturerData.setter  # type: ignore # noqa: F722
     def ManufacturerData(self, data: "a{qv}"):  # type: ignore # noqa: F821 F722
         self._manufacturer_data = data
 
@@ -89,11 +89,11 @@ class BlueZLEAdvertisement(ServiceInterface):
     # def SolicitUUIDs(self, uuids: "as"):  # type: ignore # noqa: F821 F722
         # self._solicit_uuids = uuids
 
-    @dbus_property()
+    @dbus_property()  # noqa: F722
     def ServiceData(self) -> "a{sv}":  # type: ignore # noqa: F821 F722
         return self._service_data
 
-    @ServiceData.setter  # type: ignore
+    @ServiceData.setter  # type: ignore # noqa: F722
     def ServiceData(self, data: "a{sv}"):  # type: ignore # noqa: F821 F722
         self._service_data = data
 

--- a/bless/backends/bluezdbus/dbus/application.py
+++ b/bless/backends/bluezdbus/dbus/application.py
@@ -75,13 +75,11 @@ class BlueZGattApplication(ServiceInterface):
         BlueZGattService
             Returns and instance of the service object
         """
-
         index: int = len(self.services) + 1
         primary: bool = index == 1
         service: BlueZGattService = BlueZGattService(uuid, primary, index, self)
         self.services.append(service)
         self.bus.export(service.path, service)
-        await self.bus.request_name(self.destination)
         return service
 
     async def add_characteristic(
@@ -123,7 +121,6 @@ class BlueZGattApplication(ServiceInterface):
             The adapter to register the application with
         """
         iface: ProxyInterface = adapter.get_interface(defs.GATT_MANAGER_INTERFACE)
-        print(dir(iface))
         await iface.call_register_application(  # type: ignore
             self.path,
             {}
@@ -161,7 +158,6 @@ class BlueZGattApplication(ServiceInterface):
             advertisement._service_uuids.append(service.UUID)
 
         self.bus.export(advertisement.path, advertisement)
-        await self.bus.request_name(self.destination)
 
         iface: ProxyInterface = adapter.get_interface("org.bluez.LEAdvertisingManager1")
         await iface.call_register_advertisement(  # type: ignore
@@ -229,4 +225,3 @@ class BlueZGattApplication(ServiceInterface):
         o : A service or characteristic to register
         """
         self.bus.export(o.path, o)
-        await self.bus.request_name(self.destination)

--- a/bless/backends/bluezdbus/dbus/application.py
+++ b/bless/backends/bluezdbus/dbus/application.py
@@ -2,9 +2,9 @@ import bleak.backends.bluezdbus.defs as defs  # type: ignore
 
 from typing import List, Any, Callable, Optional, Union
 
-from dbus_next.aio import MessageBus, ProxyObject, ProxyInterface
-from dbus_next.service import ServiceInterface
-from dbus_next.signature import Variant
+from dbus_next.aio import MessageBus, ProxyObject, ProxyInterface  # type: ignore
+from dbus_next.service import ServiceInterface  # type: ignore
+from dbus_next.signature import Variant  # type: ignore
 
 from bless.backends.bluezdbus.dbus.advertisement import (  # type: ignore
     Type,

--- a/bless/backends/bluezdbus/dbus/characteristic.py
+++ b/bless/backends/bluezdbus/dbus/characteristic.py
@@ -4,10 +4,10 @@ import bleak.backends.bluezdbus.defs as defs  # type: ignore
 
 from typing import List, Dict, TYPE_CHECKING
 
-from dbus_next.aio import ProxyObject, ProxyInterface
-from dbus_next.service import ServiceInterface, method, dbus_property
-from dbus_next.introspection import Node
-from dbus_next.constants import PropertyAccess
+from dbus_next.aio import ProxyObject, ProxyInterface  # type: ignore
+from dbus_next.service import ServiceInterface, method, dbus_property  # type: ignore
+from dbus_next.introspection import Node  # type: ignore
+from dbus_next.constants import PropertyAccess  # type: ignore
 
 if TYPE_CHECKING:
     from bless.backends.bluezdbus.dbus.service import (  # type: ignore

--- a/bless/backends/bluezdbus/dbus/characteristic.py
+++ b/bless/backends/bluezdbus/dbus/characteristic.py
@@ -99,11 +99,11 @@ class BlueZGattCharacteristic(ServiceInterface):
     def Notifying(self) -> "b":  # type: ignore # noqa: F821
         return self._notifying
 
-    @dbus_property(access=PropertyAccess.READ)
+    @dbus_property(access=PropertyAccess.READ)  # noqa: F722
     def Flags(self) -> "as":  # type: ignore # noqa: F821 F722
         return self._flags
 
-    @method()
+    @method()  # noqa: F722
     def ReadValue(self, options: "a{sv}") -> "ay":  # type: ignore # noqa: F722 F821
         """
         Read the value of the characteristic.
@@ -124,7 +124,7 @@ class BlueZGattCharacteristic(ServiceInterface):
             raise NotImplementedError()
         return f(self)
 
-    @method()
+    @method()  # noqa: F722
     def WriteValue(self, value: "ay", options: "a{sv}"):  # type: ignore # noqa
         """
         Write a value to the characteristic

--- a/bless/backends/bluezdbus/dbus/characteristic.py
+++ b/bless/backends/bluezdbus/dbus/characteristic.py
@@ -4,10 +4,9 @@ import bleak.backends.bluezdbus.defs as defs  # type: ignore
 
 from typing import List, Dict, TYPE_CHECKING
 
-from dbus_next.aio import ProxyObject, ProxyInterface  # type: ignore
 from dbus_next.service import ServiceInterface, method, dbus_property  # type: ignore
-from dbus_next.introspection import Node  # type: ignore
 from dbus_next.constants import PropertyAccess  # type: ignore
+from dbus_next.signature import Variant  # type: ignore
 
 if TYPE_CHECKING:
     from bless.backends.bluezdbus.dbus.service import (  # type: ignore
@@ -141,7 +140,6 @@ class BlueZGattCharacteristic(ServiceInterface):
         if f is None:
             raise NotImplementedError()
         f(self, value)
-        return value
 
     @method()
     def StartNotify(self):  # noqa: N802
@@ -175,16 +173,6 @@ class BlueZGattCharacteristic(ServiceInterface):
         Dict
             The dictionary that describes the characteristic
         """
-        bluez_node: Node = await self._service.app.bus.introspect(
-            self._service.app.destination, self.path
-        )
-        dbus_obj: ProxyObject = self._service.app.bus.get_proxy_object(
-            self._service.app.destination, self.path, bluez_node
-        )
-        dbus_iface: ProxyInterface = dbus_obj.get_interface(
-            defs.PROPERTIES_INTERFACE
-        )
-        dict_obj: Dict = await dbus_iface.call_get_all(  # type: ignore
-            defs.GATT_CHARACTERISTIC_INTERFACE
-        )
-        return dict_obj
+        return {
+            "UUID": Variant('s', self._uuid)
+        }

--- a/bless/backends/bluezdbus/dbus/service.py
+++ b/bless/backends/bluezdbus/dbus/service.py
@@ -1,9 +1,9 @@
 from typing import List, TYPE_CHECKING, Any, Dict
 
-from dbus_next.aio import MessageBus, ProxyObject, ProxyInterface  # type: ignore
+from dbus_next.aio import MessageBus  # type: ignore
 from dbus_next.service import ServiceInterface, dbus_property  # type: ignore
-from dbus_next.introspection import Node  # type: ignore
 from dbus_next.constants import PropertyAccess  # type: ignore
+from dbus_next.signature import Variant  # type: ignore
 
 from bleak.backends.bluezdbus import defs  # type: ignore
 
@@ -100,16 +100,7 @@ class BlueZGattService(ServiceInterface):
         Dict
             The dictionary that describes the service
         """
-        bluez_node: Node = await self.bus.introspect(
-            self.app.destination, self.path
-        )
-        dbus_obj: ProxyObject = self.bus.get_proxy_object(
-            self.app.destination, self.path, bluez_node
-        )
-        dbus_iface: ProxyInterface = dbus_obj.get_interface(
-            defs.PROPERTIES_INTERFACE
-        )
-        dict_obj: Dict = await dbus_iface.call_get_all(  # type: ignore
-            defs.GATT_SERVICE_INTERFACE
-        )
-        return dict_obj
+        return {
+            "Primary": Variant('b', self._primary),
+            "UUID": Variant('s', self._uuid)
+        }

--- a/bless/backends/bluezdbus/dbus/service.py
+++ b/bless/backends/bluezdbus/dbus/service.py
@@ -1,9 +1,9 @@
 from typing import List, TYPE_CHECKING, Any, Dict
 
-from dbus_next.aio import MessageBus, ProxyObject, ProxyInterface
-from dbus_next.service import ServiceInterface, dbus_property
-from dbus_next.introspection import Node
-from dbus_next.constants import PropertyAccess
+from dbus_next.aio import MessageBus, ProxyObject, ProxyInterface  # type: ignore
+from dbus_next.service import ServiceInterface, dbus_property  # type: ignore
+from dbus_next.introspection import Node  # type: ignore
+from dbus_next.constants import PropertyAccess  # type: ignore
 
 from bleak.backends.bluezdbus import defs  # type: ignore
 

--- a/bless/backends/bluezdbus/dbus/service.py
+++ b/bless/backends/bluezdbus/dbus/service.py
@@ -1,14 +1,9 @@
-import asyncio
-
 from typing import List, TYPE_CHECKING, Any, Dict
 
-from txdbus import client  # type: ignore
-from txdbus.objects import (  # type: ignore
-        DBusObject,
-        DBusProperty,
-        RemoteDBusObject
-        )
-from txdbus.interface import DBusInterface, Property  # type: ignore
+from dbus_next.aio import MessageBus, ProxyObject, ProxyInterface
+from dbus_next.service import ServiceInterface, dbus_property
+from dbus_next.introspection import Node
+from dbus_next.constants import PropertyAccess
 
 from bleak.backends.bluezdbus import defs  # type: ignore
 
@@ -20,23 +15,12 @@ if TYPE_CHECKING:
     )
 
 
-class BlueZGattService(DBusObject):
+class BlueZGattService(ServiceInterface):
     """
     org.bluez.GattService1 interface implementation
     """
 
     interface_name: str = defs.GATT_SERVICE_INTERFACE
-
-    iface: DBusInterface = DBusInterface(
-        interface_name,
-        Property("UUID", "s"),
-        Property("Primary", "b"),
-    )
-
-    dbusInterfaces: List[DBusInterface] = [iface]
-
-    uuid: DBusProperty = DBusProperty("UUID")
-    primary: DBusProperty = DBusProperty("Primary")
 
     def __init__(
         self,
@@ -63,15 +47,24 @@ class BlueZGattService(DBusObject):
         """
         hex_index: str = hex(index)[2:].rjust(4, "0")
         self.path: str = app.base_path + "/service" + hex_index
-        self.bus: client = app.bus
+        self.bus: MessageBus = app.bus
         self.destination: str = app.destination
-        self.uuid: str = uuid
-        self.primary: bool = primary
-        self.loop: asyncio.AbstractEventLoop = app.loop
+
+        self._uuid: str = uuid
+        self._primary: bool = primary
+
         self.app: "BlueZGattApplication" = app  # noqa: F821
 
         self.characteristics: List[BlueZGattCharacteristic] = []
-        super(BlueZGattService, self).__init__(self.path)
+        super(BlueZGattService, self).__init__(self.interface_name)
+
+    @dbus_property(access=PropertyAccess.READ)
+    def UUID(self) -> "s":  # type: ignore # noqa: F821
+        return self._uuid
+
+    @dbus_property(access=PropertyAccess.READ)
+    def Primary(self) -> "b":  # type: ignore # noqa: F821
+        return self._primary
 
     async def add_characteristic(
         self, uuid: str, flags: List[Flags], value: Any
@@ -92,7 +85,7 @@ class BlueZGattService(DBusObject):
         characteristic: BlueZGattCharacteristic = BlueZGattCharacteristic(
             uuid, flags, index, self
         )
-        characteristic.value = value
+        characteristic._value = value  # type: ignore
         self.characteristics.append(characteristic)
         await self.app._register_object(characteristic)
         return characteristic
@@ -107,12 +100,16 @@ class BlueZGattService(DBusObject):
         Dict
             The dictionary that describes the service
         """
-        dbus_obj: RemoteDBusObject = await self.app.bus.getRemoteObject(
+        bluez_node: Node = await self.bus.introspect(
             self.app.destination, self.path
-        ).asFuture(self.app.loop)
-        dict_obj: Dict = await dbus_obj.callRemote(
-            "GetAll",
-            defs.GATT_SERVICE_INTERFACE,
-            interface=defs.PROPERTIES_INTERFACE,
-        ).asFuture(self.app.loop)
+        )
+        dbus_obj: ProxyObject = self.bus.get_proxy_object(
+            self.app.destination, self.path, bluez_node
+        )
+        dbus_iface: ProxyInterface = dbus_obj.get_interface(
+            defs.PROPERTIES_INTERFACE
+        )
+        dict_obj: Dict = await dbus_iface.call_get_all(  # type: ignore
+            defs.GATT_SERVICE_INTERFACE
+        )
         return dict_obj

--- a/bless/backends/bluezdbus/dbus/utils.py
+++ b/bless/backends/bluezdbus/dbus/utils.py
@@ -1,44 +1,63 @@
-import asyncio
-
 import bleak.backends.bluezdbus.defs as defs  # type: ignore
 
-from typing import Dict, Optional
+from typing import Dict, Optional, cast
 
-from txdbus import client  # type: ignore
-from txdbus.objects import RemoteDBusObject  # type: ignore
+from dbus_next.aio import MessageBus, ProxyObject, ProxyInterface
+from dbus_next.introspection import Node
 
 
-async def find_adapter(bus: client, loop: asyncio.AbstractEventLoop) -> Optional[str]:
+async def find_adapter(bus: MessageBus) -> Optional[str]:
     """
-    Returns the first object that the bluez service has that has a GattManager1
+    Returns the first object within the bluez service that has a GattManager1
     interface
+
+    Parameters
+    ----------
+    bus : MessageBus
+        The currently connected message bus to communicate with BlueZ
+
+    Returns
+    -------
+    Optional[str]
+        The name of the adapter interface on the dbus.
+        None if it does not find an adapter
     """
-    bluez_obj: RemoteDBusObject = await bus.getRemoteObject(
-        defs.BLUEZ_SERVICE, "/"
-    ).asFuture(loop)
+    bluez_node: Node = await bus.introspect(defs.BLUEZ_SERVICE, "/")
+    bluez_obj: ProxyObject = bus.get_proxy_object(defs.BLUEZ_SERVICE, "/", bluez_node)
+    interface: ProxyInterface = bluez_obj.get_interface(
+        defs.OBJECT_MANAGER_INTERFACE
+    )
+    bt_objects: Dict = await interface.call_get_managed_objects()  # type: ignore
 
-    om_objects: Dict = await bluez_obj.callRemote(
-        "GetManagedObjects", interface=defs.OBJECT_MANAGER_INTERFACE
-    ).asFuture(loop)
-
-    for o, props in om_objects.items():
+    for objs, props in bt_objects.items():
         if defs.GATT_MANAGER_INTERFACE in props.keys():
-            return o
+            return objs
 
     return None
 
 
-async def get_adapter(bus: client, loop: asyncio.AbstractEventLoop) -> RemoteDBusObject:
+async def get_adapter(bus: MessageBus) -> Optional[ProxyObject]:
     """
     Gets the bluetooth adapter
 
+    Parameters
+    ----------
+    bus : MessageBus
+        The connected DBus object
+
     Returns
     -------
-    DBusObject
+    Optional[ProxyObject]
         The adapter object
+        None if not found
     """
-    adapter_path: Optional[str] = await find_adapter(bus, loop)
-    adapter_obj: RemoteDBusObject = await bus.getRemoteObject(
-        defs.BLUEZ_SERVICE, adapter_path
-    ).asFuture(loop)
+    oadapter_path: Optional[str] = await find_adapter(bus)
+    if oadapter_path is None:
+        return None
+
+    adapter_path: str = cast(str, oadapter_path)
+    adapter_node: Node = await bus.introspect(defs.BLUEZ_SERVICE, adapter_path)
+    adapter_obj: ProxyObject = bus.get_proxy_object(
+        defs.BLUEZ_SERVICE, adapter_path, adapter_node
+    )
     return adapter_obj

--- a/bless/backends/bluezdbus/dbus/utils.py
+++ b/bless/backends/bluezdbus/dbus/utils.py
@@ -2,8 +2,8 @@ import bleak.backends.bluezdbus.defs as defs  # type: ignore
 
 from typing import Dict, Optional, cast
 
-from dbus_next.aio import MessageBus, ProxyObject, ProxyInterface
-from dbus_next.introspection import Node
+from dbus_next.aio import MessageBus, ProxyObject, ProxyInterface  # type: ignore
+from dbus_next.introspection import Node  # type: ignore
 
 
 async def find_adapter(bus: MessageBus) -> Optional[str]:

--- a/bless/backends/bluezdbus/server.py
+++ b/bless/backends/bluezdbus/server.py
@@ -6,8 +6,8 @@ from typing import Optional, Dict, Any, cast
 
 from asyncio import AbstractEventLoop
 
-from dbus_next.aio import MessageBus, ProxyObject
-from dbus_next.constants import BusType
+from dbus_next.aio import MessageBus, ProxyObject  # type: ignore
+from dbus_next.constants import BusType  # type: ignore
 
 from bless.backends.server import BaseBlessServer  # type: ignore
 from bless.backends.bluezdbus.characteristic import BlessGATTCharacteristicBlueZDBus

--- a/bless/backends/bluezdbus/server.py
+++ b/bless/backends/bluezdbus/server.py
@@ -54,7 +54,7 @@ class BlessServerBlueZDBus(BaseBlessServer):
 
         gatt_name: str = self.name.replace(" ", "")
         self.app: BlueZGattApplication = BlueZGattApplication(
-            gatt_name, "org.bluez." + gatt_name, self.bus
+            gatt_name, "org.bluez", self.bus
         )
 
         self.app.Read = self.read

--- a/bless/backends/bluezdbus/server.py
+++ b/bless/backends/bluezdbus/server.py
@@ -82,7 +82,6 @@ class BlessServerBlueZDBus(BaseBlessServer):
 
         # Make our app available
         self.bus.export(self.app.path, self.app)
-        await self.bus.request_name(self.app.destination)
 
         # Register
         await self.app.register(self.adapter)

--- a/bless/backends/bluezdbus/server.py
+++ b/bless/backends/bluezdbus/server.py
@@ -2,12 +2,12 @@ import asyncio
 
 from uuid import UUID
 
-from typing import Optional, Dict, Any, cast, List
+from typing import Optional, Dict, Any, cast
 
 from asyncio import AbstractEventLoop
-from twisted.internet.asyncioreactor import AsyncioSelectorReactor  # type: ignore
-from txdbus import client  # type: ignore
-from txdbus.objects import RemoteDBusObject  # type: ignore
+
+from dbus_next.aio import MessageBus, ProxyObject
+from dbus_next.constants import BusType
 
 from bless.backends.server import BaseBlessServer  # type: ignore
 from bless.backends.bluezdbus.characteristic import BlessGATTCharacteristicBlueZDBus
@@ -41,9 +41,6 @@ class BlessServerBlueZDBus(BaseBlessServer):
     def __init__(self, name: str, loop: AbstractEventLoop = None, **kwargs):
         super(BlessServerBlueZDBus, self).__init__(loop=loop, **kwargs)
         self.name: str = name
-        self.reactor: AsyncioSelectorReactor = AsyncioSelectorReactor(
-            cast(asyncio.unix_events._UnixSelectorEventLoop, loop)
-        )
 
         self.services: Dict[str, BlessGATTServiceBlueZDBus] = {}
 
@@ -53,13 +50,11 @@ class BlessServerBlueZDBus(BaseBlessServer):
         """
         Asyncronous side of init
         """
-        self.bus: client = await client.connect(self.reactor, "system").asFuture(
-            self.loop
-        )
+        self.bus: MessageBus = await MessageBus(bus_type=BusType.SYSTEM).connect()
 
         gatt_name: str = self.name.replace(" ", "")
         self.app: BlueZGattApplication = BlueZGattApplication(
-            gatt_name, "org.bluez." + gatt_name, self.bus, self.loop
+            gatt_name, "org.bluez." + gatt_name, self.bus
         )
 
         self.app.Read = self.read
@@ -69,7 +64,10 @@ class BlessServerBlueZDBus(BaseBlessServer):
         self.app.StartNotify = lambda x: None
         self.app.StopNotify = lambda x: None
 
-        self.adapter: RemoteDBusObject = await get_adapter(self.bus, self.loop)
+        potential_adapter: Optional[ProxyObject] = await get_adapter(self.bus)
+        if potential_adapter is None:
+            raise Exception("Could not locate bluetooth adapter")
+        self.adapter: ProxyObject = cast(ProxyObject, potential_adapter)
 
     async def start(self, **kwargs) -> bool:
         """
@@ -83,8 +81,8 @@ class BlessServerBlueZDBus(BaseBlessServer):
         await self.setup_task
 
         # Make our app available
-        self.bus.exportObject(self.app)
-        await self.bus.requestBusName(self.app.destination).asFuture(self.loop)
+        self.bus.export(self.app.path, self.app)
+        await self.bus.request_name(self.app.destination)
 
         # Register
         await self.app.register(self.adapter)
@@ -220,10 +218,10 @@ class BlessServerBlueZDBus(BaseBlessServer):
         cur_value: Any = bless_char.value
 
         characteristic: BlueZGattCharacteristic = bless_char.gatt
-        characteristic.value = cur_value
+        characteristic.Value = bytes(cur_value)  # type: ignore
         return True
 
-    def read(self, char: BlueZGattCharacteristic) -> List[int]:
+    def read(self, char: BlueZGattCharacteristic) -> bytes:
         """
         Read request.
         This re-routes the the request incomming on the dbus to the server to
@@ -238,12 +236,12 @@ class BlessServerBlueZDBus(BaseBlessServer):
 
         Returns
         -------
-        List[int]
+        bytes
             The value of the characteristic
         """
-        return list(self.read_request(char.uuid))
+        return bytes(self.read_request(char.UUID))
 
-    def write(self, char: BlueZGattCharacteristic, value: bytearray):
+    def write(self, char: BlueZGattCharacteristic, value: bytes):
         """
         Write request.
         This function re-routes the write request sent from the
@@ -257,4 +255,4 @@ class BlessServerBlueZDBus(BaseBlessServer):
         value : bytearray
             The value being requested to set
         """
-        return self.write_request(char.uuid, value)
+        return self.write_request(char.UUID, bytearray(value))

--- a/bless/backends/bluezdbus/service.py
+++ b/bless/backends/bluezdbus/service.py
@@ -52,7 +52,7 @@ class BlessGATTServiceBlueZDBus(BlessGATTService, BleakGATTServiceBlueZDBus):
     @property
     def uuid(self) -> str:
         """UUID for this service"""
-        return self.obj["UUID"]
+        return self.obj["UUID"].value
 
     @property
     def characteristics(self) -> List[BlessGATTCharacteristicBlueZDBus]:

--- a/examples/gattserver.py
+++ b/examples/gattserver.py
@@ -10,7 +10,7 @@ import threading
 
 from typing import Any, Dict
 
-from bless import (
+from bless import (  # type: ignore
         BlessServer,
         BlessGATTCharacteristic,
         GATTCharacteristicProperties,

--- a/examples/server.py
+++ b/examples/server.py
@@ -9,7 +9,7 @@ import threading
 
 from typing import Any
 
-from bless import (
+from bless import (  # type: ignore
         BlessServer,
         BlessGATTCharacteristic,
         GATTCharacteristicProperties,

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ aioconsole
 numpy
 pyobjc; platform_system == "Darwin"
 twisted; platform_system == "Linux"
-txdbus; platform_system == "Linux"
+dbus-next; platform_system == "Linux"

--- a/test/backends/test_server.py
+++ b/test/backends/test_server.py
@@ -69,7 +69,7 @@ class TestBlessServer:
         await server.add_new_service(service_uuid)
 
         assert len(server.services) > 0
-        print(server.services)
+        # print(server.services)
 
         # setup a characteristic for the service
         char_uuid: str = str(uuid.uuid4())


### PR DESCRIPTION
Resolves #60 

# Changed
- Replaced txdbus dependency to dbus-next
- Drop support for python 3.6

# Fixed
- Security issues. Requesting names on DBus is not necessary and requires inappropriate elevation of privileges. These changes remove the need for iterative introspection and request new object names.