### PR TITLE
Update to bluez 5.64 dbus advertising API

### DIFF
--- a/bless/backends/bluezdbus/dbus/advertisement.py
+++ b/bless/backends/bluezdbus/dbus/advertisement.py
@@ -51,6 +51,7 @@ class BlueZLEAdvertisement(ServiceInterface):
         self._service_data: Dict = {}
 
         self._tx_power: int = 20
+        self._local_name = app.app_name
 
         self.data = None
         super(BlueZLEAdvertisement, self).__init__(self.interface_name)
@@ -114,3 +115,11 @@ class BlueZLEAdvertisement(ServiceInterface):
     @TxPower.setter  # type: ignore
     def TxPower(self, dbm: "n"):  # type: ignore # noqa: F821
         self._tx_power = dbm
+
+    @dbus_property()
+    def LocalName(self) -> "s":  # type: ignore # noqa: F821
+        return self._local_name
+
+    @LocalName.setter
+    def LocalName(self, name: str):  # type: ignore # noqa: F821
+        self._local_name = name

--- a/bless/backends/bluezdbus/dbus/advertisement.py
+++ b/bless/backends/bluezdbus/dbus/advertisement.py
@@ -18,6 +18,8 @@ class Type(Enum):
 class BlueZLEAdvertisement(ServiceInterface):
     """
     org.bluez.LEAdvertisement1 interface implementation
+
+    https://github.com/bluez/bluez/blob/5.64/doc/advertising-api.txt
     """
 
     interface_name: str = "org.bluez.LEAdvertisement1"
@@ -48,7 +50,7 @@ class BlueZLEAdvertisement(ServiceInterface):
         self._solicit_uuids: List[str] = [""]
         self._service_data: Dict = {}
 
-        self._include_tx_power: bool = False
+        self._tx_power: int = 20
 
         self.data = None
         super(BlueZLEAdvertisement, self).__init__(self.interface_name)
@@ -97,10 +99,18 @@ class BlueZLEAdvertisement(ServiceInterface):
     def ServiceData(self, data: "a{sv}"):  # type: ignore # noqa: F821 F722
         self._service_data = data
 
-    @dbus_property()
-    def IncludeTxPower(self) -> "b":  # type: ignore # noqa: F821
-        return self._include_tx_power
+    # @dbus_property()
+    # def Includes(self) -> "as": # type: ignore # noqa: F821
+    #     return ["tx-power", "local-name"]
 
-    @IncludeTxPower.setter  # type: ignore
-    def IncludeTxPower(self, include: "b"):  # type: ignore # noqa: F821
-        self._include_tx_power = include
+    # @Includes.setter
+    # def Includes(self, include): # type: ignore # noqa: F821
+    #     pass
+
+    @dbus_property()
+    def TxPower(self) -> "n":  # type: ignore # noqa: F821
+        return self._tx_power
+
+    @TxPower.setter  # type: ignore
+    def TxPower(self, dbm: "n"):  # type: ignore # noqa: F821
+        self._tx_power = dbm

--- a/bless/backends/bluezdbus/dbus/application.py
+++ b/bless/backends/bluezdbus/dbus/application.py
@@ -45,7 +45,7 @@ class BlueZGattApplication(ServiceInterface):
         self.destination: str = destination
         self.bus: MessageBus = bus
 
-        self.base_path: str = "/org/bluez/" + self.app_name
+        self.base_path: str = "/org/bluez/" + self.app_name.replace(" ", "")
         self.advertisements: List[BlueZLEAdvertisement] = []
         self.services: List[BlueZGattService] = []
 

--- a/bless/backends/bluezdbus/server.py
+++ b/bless/backends/bluezdbus/server.py
@@ -52,9 +52,8 @@ class BlessServerBlueZDBus(BaseBlessServer):
         """
         self.bus: MessageBus = await MessageBus(bus_type=BusType.SYSTEM).connect()
 
-        gatt_name: str = self.name.replace(" ", "")
         self.app: BlueZGattApplication = BlueZGattApplication(
-            gatt_name, "org.bluez", self.bus
+            self.name, "org.bluez", self.bus
         )
 
         self.app.Read = self.read


### PR DESCRIPTION
Fixes #80.

`TxPower` property is needed with bluez 5.47+
https://github.com/bluez/bluez/commit/9fb1f9ff694c387e7547b897ff1cd4c95d1063da
`IncludeTxPower` was removed, this now under `Includes` and not required.

Also fixes the name in the advertising packet with the `LocalName` property. 
Note that setting the adapter alias is not strictly required, but I left it in - could be useful if there are multiple adapters/applications running on the same host.