### PR TITLE
83 windows local name

### DIFF
--- a/bless/backends/bluezdbus/characteristic.py
+++ b/bless/backends/bluezdbus/characteristic.py
@@ -10,13 +10,15 @@ if TYPE_CHECKING:
     from bless.backends.bluezdbus.service import BlessGATTServiceBlueZDBus
     from bless.backends.service import BlessGATTService
 
-from bless.backends.characteristic import (
+from bless.backends.characteristic import (  # noqa: E402
     BlessGATTCharacteristic,
     GATTCharacteristicProperties,
     GATTAttributePermissions,
 )
 
-from bless.backends.bluezdbus.dbus.characteristic import Flags, BlueZGattCharacteristic
+from bless.backends.bluezdbus.dbus.characteristic import (  # noqa: E402
+    Flags, BlueZGattCharacteristic
+)
 
 
 class BlessGATTCharacteristicBlueZDBus(

--- a/bless/backends/bluezdbus/dbus/advertisement.py
+++ b/bless/backends/bluezdbus/dbus/advertisement.py
@@ -61,27 +61,27 @@ class BlueZLEAdvertisement(ServiceInterface):
         print("%s: Released!" % self.path)
 
     @dbus_property()
-    def Type(self) -> "s":  # type: ignore # noqa: F821
+    def Type(self) -> "s":  # type: ignore # noqa: F821 N802
         return self._type
 
     @Type.setter  # type: ignore
-    def Type(self, type: "s"):  # type: ignore # noqa: F821 F722
+    def Type(self, type: "s"):  # type: ignore # noqa: F821 F722 N802
         self._type = type
 
     @dbus_property()  # noqa: F722
-    def ServiceUUIDs(self) -> "as":  # type: ignore # noqa: F821 F722
+    def ServiceUUIDs(self) -> "as":  # type: ignore # noqa: F821 F722 N802
         return self._service_uuids
 
     @ServiceUUIDs.setter  # type: ignore # noqa: 722
-    def ServiceUUIDs(self, service_uuids: "as"):  # type: ignore # noqa: F821 F722
+    def ServiceUUIDs(self, service_uuids: "as"):  # type: ignore # noqa: F821 F722 N802
         self._service_uuids = service_uuids
 
     @dbus_property()  # noqa: 722
-    def ManufacturerData(self) -> "a{qv}":  # type: ignore # noqa: F821 F722
+    def ManufacturerData(self) -> "a{qv}":  # type: ignore # noqa: F821 F722 N802
         return self._manufacturer_data
 
     @ManufacturerData.setter  # type: ignore # noqa: F722
-    def ManufacturerData(self, data: "a{qv}"):  # type: ignore # noqa: F821 F722
+    def ManufacturerData(self, data: "a{qv}"):  # type: ignore # noqa: F821 F722 N802
         self._manufacturer_data = data
 
     # @dbus_property()
@@ -93,11 +93,11 @@ class BlueZLEAdvertisement(ServiceInterface):
         # self._solicit_uuids = uuids
 
     @dbus_property()  # noqa: F722
-    def ServiceData(self) -> "a{sv}":  # type: ignore # noqa: F821 F722
+    def ServiceData(self) -> "a{sv}":  # type: ignore # noqa: F821 F722 N802
         return self._service_data
 
     @ServiceData.setter  # type: ignore # noqa: F722
-    def ServiceData(self, data: "a{sv}"):  # type: ignore # noqa: F821 F722
+    def ServiceData(self, data: "a{sv}"):  # type: ignore # noqa: F821 F722 N802
         self._service_data = data
 
     # @dbus_property()
@@ -109,17 +109,17 @@ class BlueZLEAdvertisement(ServiceInterface):
     #     pass
 
     @dbus_property()
-    def TxPower(self) -> "n":  # type: ignore # noqa: F821
+    def TxPower(self) -> "n":  # type: ignore # noqa: F821 N802
         return self._tx_power
 
     @TxPower.setter  # type: ignore
-    def TxPower(self, dbm: "n"):  # type: ignore # noqa: F821
+    def TxPower(self, dbm: "n"):  # type: ignore # noqa: F821 N802
         self._tx_power = dbm
 
     @dbus_property()
-    def LocalName(self) -> "s":  # type: ignore # noqa: F821
+    def LocalName(self) -> "s":  # type: ignore # noqa: F821 N802
         return self._local_name
 
     @LocalName.setter  # type: ignore
-    def LocalName(self, name: str):  # type: ignore # noqa: F821
+    def LocalName(self, name: str):  # type: ignore # noqa: F821 N802
         self._local_name = name

--- a/bless/backends/bluezdbus/dbus/characteristic.py
+++ b/bless/backends/bluezdbus/dbus/characteristic.py
@@ -9,9 +9,9 @@ from dbus_next.constants import PropertyAccess  # type: ignore
 from dbus_next.signature import Variant  # type: ignore
 
 if TYPE_CHECKING:
-    from bless.backends.bluezdbus.dbus.service import (  # type: ignore
+    from bless.backends.bluezdbus.dbus.service import (  # type: ignore # noqa: F401
         BlueZGattService,
-        BlueZGattDescriptor,
+        BlueZGattDescriptor
     )
 
 
@@ -76,34 +76,34 @@ class BlueZGattCharacteristic(ServiceInterface):
         super(BlueZGattCharacteristic, self).__init__(self.interface_name)
 
     @dbus_property(access=PropertyAccess.READ)
-    def UUID(self) -> "s":  # type: ignore # noqa: F821
+    def UUID(self) -> "s":  # type: ignore # noqa: F821 N802
         return self._uuid
 
     @dbus_property(access=PropertyAccess.READ)
-    def Service(self) -> "o":  # type: ignore # noqa: F821
+    def Service(self) -> "o":  # type: ignore # noqa: F821 N802
         return self._service_path
 
     @dbus_property()
-    def Value(self) -> "ay":  # type: ignore # noqa: F821
+    def Value(self) -> "ay":  # type: ignore # noqa: F821 N802
         return self._value
 
     @Value.setter  # type: ignore
-    def Value(self, value: "ay"):  # type: ignore # noqa: F821
+    def Value(self, value: "ay"):  # type: ignore # noqa: F821 N802
         self._value = value
         self.emit_properties_changed(
             changed_properties={"Value": self._value}
         )
 
     @dbus_property(access=PropertyAccess.READ)
-    def Notifying(self) -> "b":  # type: ignore # noqa: F821
+    def Notifying(self) -> "b":  # type: ignore # noqa: F821 N802
         return self._notifying
 
     @dbus_property(access=PropertyAccess.READ)  # noqa: F722
-    def Flags(self) -> "as":  # type: ignore # noqa: F821 F722
+    def Flags(self) -> "as":  # type: ignore # noqa: F821 F722 N802
         return self._flags
 
     @method()  # noqa: F722
-    def ReadValue(self, options: "a{sv}") -> "ay":  # type: ignore # noqa: F722 F821
+    def ReadValue(self, options: "a{sv}") -> "ay":  # type: ignore # noqa: F722 F821 N802 E501
         """
         Read the value of the characteristic.
         This is to be fully implemented at the application level

--- a/bless/backends/bluezdbus/dbus/service.py
+++ b/bless/backends/bluezdbus/dbus/service.py
@@ -59,11 +59,11 @@ class BlueZGattService(ServiceInterface):
         super(BlueZGattService, self).__init__(self.interface_name)
 
     @dbus_property(access=PropertyAccess.READ)
-    def UUID(self) -> "s":  # type: ignore # noqa: F821
+    def UUID(self) -> "s":  # type: ignore # noqa: F821 N802
         return self._uuid
 
     @dbus_property(access=PropertyAccess.READ)
-    def Primary(self) -> "b":  # type: ignore # noqa: F821
+    def Primary(self) -> "b":  # type: ignore # noqa: F821 N802
         return self._primary
 
     async def add_characteristic(

--- a/bless/backends/corebluetooth/characteristic.py
+++ b/bless/backends/corebluetooth/characteristic.py
@@ -2,10 +2,7 @@ from enum import Flag
 from uuid import UUID
 from typing import Union, Optional
 
-from CoreBluetooth import (  # type: ignore
-        CBUUID,
-        CBMutableCharacteristic
-        )
+from CoreBluetooth import CBUUID, CBMutableCharacteristic  # type: ignore
 
 from bleak.backends.corebluetooth.characteristic import (  # type: ignore
     BleakGATTCharacteristicCoreBluetooth,
@@ -14,10 +11,10 @@ from bleak.backends.corebluetooth.characteristic import (  # type: ignore
 from bless.backends.service import BlessGATTService
 
 from bless.backends.characteristic import (
-        GATTCharacteristicProperties,
-        GATTAttributePermissions,
-        BlessGATTCharacteristic
-        )
+    GATTCharacteristicProperties,
+    GATTAttributePermissions,
+    BlessGATTCharacteristic,
+)
 
 
 class CBAttributePermissions(Flag):
@@ -39,7 +36,7 @@ class BlessGATTCharacteristicCoreBluetooth(
         uuid: Union[str, UUID],
         properties: GATTCharacteristicProperties,
         permissions: GATTAttributePermissions,
-        value: Optional[bytearray]
+        value: Optional[bytearray],
     ):
         """
         Instantiates a new GATT Characteristic but is not yet assigned to any
@@ -75,7 +72,9 @@ class BlessGATTCharacteristicCoreBluetooth(
                 cb_uuid, properties_value, self._initial_value, permissions_value
             )
         )
-        super(BlessGATTCharacteristic, self).__init__(obj=cb_characteristic)
+        super(BleakGATTCharacteristicCoreBluetooth, self).__init__(  # type: ignore
+            obj=cb_characteristic
+        )
 
     @property
     def value(self) -> bytearray:

--- a/bless/backends/corebluetooth/service.py
+++ b/bless/backends/corebluetooth/service.py
@@ -1,15 +1,12 @@
 from uuid import UUID
-from typing import List, Union
+from typing import Union
 
 from CoreBluetooth import CBMutableService, CBUUID  # type: ignore
 
 from bleak.backends.corebluetooth.utils import cb_uuid_to_str  # type: ignore
-from bless.backends.corebluetooth.characteristic import (
-    BlessGATTCharacteristicCoreBluetooth,
-)
 from bleak.backends.corebluetooth.service import (  # type: ignore
-        BleakGATTServiceCoreBluetooth
-        )
+    BleakGATTServiceCoreBluetooth
+)
 
 from bless.backends.service import BlessGATTService
 from bless.backends.server import BaseBlessServer
@@ -30,7 +27,6 @@ class BlessGATTServiceCoreBluetooth(BlessGATTService, BleakGATTServiceCoreBlueto
             The uuid to assign to the service
         """
         super(BlessGATTServiceCoreBluetooth, self).__init__(uuid)
-        self.__characteristics: List[BlessGATTCharacteristicCoreBluetooth] = []
         self.__handle = 0
 
     async def init(self, server: "BaseBlessServer"):
@@ -42,8 +38,8 @@ class BlessGATTServiceCoreBluetooth(BlessGATTService, BleakGATTServiceCoreBlueto
             service_uuid, True
         )
 
-        # Cannot call this because of handle issue
         # super(BlessGATTService, self).__init__(obj=cb_service)
+        setattr(self, "_BleakGATTServiceCoreBluetooth__characteristics", [])
         self.obj = cb_service
 
     @property

--- a/bless/backends/winrt/ble/__init__.py
+++ b/bless/backends/winrt/ble/__init__.py
@@ -1,0 +1,3 @@
+from .adapter import BLEAdapter
+
+BLEAdapter

--- a/bless/backends/winrt/ble/adpater.py
+++ b/bless/backends/winrt/ble/adpater.py
@@ -1,0 +1,60 @@
+import winreg
+
+from pysetupdi import devices
+from pywin32 import win32file, win32api
+from pywin32.win32con import GENERIC_WRITE, OPEN_EXISTING
+
+
+class BLEAdapter:
+    def __init__(self):
+        self._dev: int = None
+        self._adapter_name: str = get_bluetooth_adapter()
+        self._device_guid: str = "{a5dcbf10-6530-11d2-901f-00c04fb951ed}"
+        self._device_name_: str = self._adapter_name.replace("\\", "#")
+        self._filename: str = "\\\\.\\" + self._device_name + "#" + self._device_guid
+
+        self._dev: int = win32file.CreateFile(
+            self._filename, GENERIC_WRITE, 0, None, OPEN_EXISTING, 0, None
+        )
+
+        if self._dev == -1:
+            raise Exception("Failed to open a connection to the bluetooth adapter")
+
+    def set_local_name(self, local_name: str):
+        self._set_registry_name(local_name)
+        self._restart_device()
+
+    def _set_registry_name(self, local_name: str):
+        local_name_key: str = (
+            f"SYSTEM\\ControlSet001\\Enum\\{self._adapter_name}\\Device Parameters"
+        )
+        key = winreg.OpenKeyEx(
+            winreg.HKEY_LOCAL_MACHINE, local_name_key, 0, winreg.KEY_SET_VALUE
+        )
+
+        winreg.SetValueEx(
+            key, "Local Name", 0, winreg.REG_BINARY, local_name
+        )
+        winreg.CloseKey(key)
+
+    def _restart_device(self):
+        os_major_version: int = win32api.GetVersionEx()[0]
+        control_code: int = 0x220fd4 if os_major_version < 6 else 0x411008
+        reload_command: int = 4
+        win32file.DeviceIoControl(self._dev, control_code, reload_command, 0)
+
+
+def get_bluetooth_adapter() -> str:
+    """
+    Retrieve the instance id of the bluetooth device on the system
+
+    Returns
+    -------
+    str
+        The string that points to the device IO file on win32
+    """
+    bluetooth_device_guid: str = "{e0cbf06c-cd8b-4647-bb8a-263b43f0f974}"
+    for bluetooth_device in devices(bluetooth_device_guid):
+        if bluetooth_device._instance_id[:3] == "USB":
+            return bluetooth_device._instance_id
+    return ""

--- a/bless/backends/winrt/server.py
+++ b/bless/backends/winrt/server.py
@@ -16,6 +16,9 @@ from bless.backends.winrt.characteristic import (  # type: ignore
     BlessGATTCharacteristicWinRT,
 )
 
+
+from bless.backends.winrt.ble import BLEAdapter
+
 # CLR imports
 # Import of Bleak CLR->UWP Bridge.
 # from BleakBridge import Bridge
@@ -68,6 +71,7 @@ class BlessServerWinRT(BaseBlessServer):
 
         self._advertising: bool = False
         self._advertising_started: Event = Event()
+        self._adapter: BLEAdapter = BLEAdapter()
 
     async def start(self, **kwargs):
         """
@@ -80,6 +84,7 @@ class BlessServerWinRT(BaseBlessServer):
             on-board bluetooth module to power on
         """
 
+        self._adapter.set_local_name(self.name)
         adv_parameters: GattServiceProviderAdvertisingParameters = (
             GattServiceProviderAdvertisingParameters()
         )

--- a/bless/backends/winrt/service.py
+++ b/bless/backends/winrt/service.py
@@ -31,8 +31,9 @@ class BlessGATTServiceWinRT(BlessGATTService, BleakGATTServiceWinRT):
             The UUID to assign to the service
         """
         super(BlessGATTServiceWinRT, self).__init__(uuid)
-        self.__characteristics: List[BlessGATTCharacteristicWinRT] = []
-        self.__handle = 0
+        super(BlessGATTService, self).__init__(uuid)
+        # self.__characteristics: List[BlessGATTCharacteristicWinRT] = []
+        # self.__handle = 0
 
     async def init(self, server: "BaseBlessServer"):
         """

--- a/bless/backends/winrt/service.py
+++ b/bless/backends/winrt/service.py
@@ -1,5 +1,5 @@
 from uuid import UUID
-from typing import List, Union, cast, TYPE_CHECKING
+from typing import Union, cast, TYPE_CHECKING
 
 from bleak_winrt.windows.devices.bluetooth.genericattributeprofile import (  # type: ignore # noqa: E501
     GattServiceProviderResult,
@@ -9,7 +9,6 @@ from bleak_winrt.windows.devices.bluetooth.genericattributeprofile import (  # t
 
 from bleak.backends.winrt.service import BleakGATTServiceWinRT  # type: ignore
 from bless.backends.service import BlessGATTService
-from bless.backends.winrt.characteristic import BlessGATTCharacteristicWinRT
 
 if TYPE_CHECKING:
     from bless.backends.server import BaseBlessServer
@@ -56,13 +55,3 @@ class BlessGATTServiceWinRT(BlessGATTService, BleakGATTServiceWinRT):
         )
         new_service: GattLocalService = self.service_provider.service
         self.obj = new_service
-
-    @property
-    def handle(self) -> int:
-        """The integer handle of the service"""
-        return self.__handle
-
-    @property
-    def uuid(self) -> str:
-        """UUID for this service"""
-        return str(self.obj.uuid)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ numpy
 pyobjc; platform_system == "Darwin"
 twisted; platform_system == "Linux"
 dbus-next; platform_system == "Linux"
+git+https://github.com/gwangyi/pysetupdi; platform_system == "Windows"
+pywin32; platform_system == "Windows"

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,9 @@ setuptools.setup(
     include_package_data=True,
     install_requires=[
         "bleak",
-        ],
+        "pywin32;platform_system=='Windows'",
+        "pysetupdi @ git+https://github.com/gwangyi/pysetupdi#egg=pysetupdi;platform_system=='Windows'"  # noqa: E501
+    ],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/test/backends/bluezdbus/test_application.py
+++ b/test/backends/bluezdbus/test_application.py
@@ -10,8 +10,8 @@ if sys.platform.lower() != "linux":
 
 from typing import List, Optional, cast  # noqa: E402
 
-from dbus_next.aio import MessageBus, ProxyObject
-from dbus_next.constants import BusType
+from dbus_next.aio import MessageBus, ProxyObject  # noqa: E402
+from dbus_next.constants import BusType  # noqa: E402
 
 from bless.backends.bluezdbus.dbus.characteristic import Flags  # type: ignore # noqa: E402 E501
 from bless.backends.bluezdbus.dbus.utils import get_adapter  # type: ignore # noqa: E402 E501

--- a/test/backends/corebluetooth/test_peripheralmanagerdelegate.py
+++ b/test/backends/corebluetooth/test_peripheralmanagerdelegate.py
@@ -12,7 +12,7 @@ from typing import Dict, Any, List, Optional
 if sys.platform.lower() != "darwin":
     pytest.skip("Only for MacOS", allow_module_level=True)
 
-from CoreBluetooth import (
+from CoreBluetooth import (  # noqa: E402
     CBUUID,
     CBMutableCharacteristic,
     CBMutableService,


### PR DESCRIPTION
Addressed, to some extent, issue #83

This is more of a workaround than a solution. WinRT reserves some of the bluetooth advertising packet properties, `local_name` (the property that broadcasts the name of the service) is[one of those reserved properties](https://docs.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.advertisement.bluetoothleadvertisementpublisher?view=winrt-22621).

However, the workaround is to change the name the device broadcasts for everything by renaming the bluetooth module within the bluetooth windows associated registry key.