### PR TITLE
Fix CoreBluetooth characteristic init missing without response size

### DIFF
--- a/bless/backends/corebluetooth/characteristic.py
+++ b/bless/backends/corebluetooth/characteristic.py
@@ -73,7 +73,8 @@ class BlessGATTCharacteristicCoreBluetooth(
             )
         )
         super(BleakGATTCharacteristicCoreBluetooth, self).__init__(  # type: ignore
-            obj=cb_characteristic
+            obj=cb_characteristic,
+            max_write_without_response_size=0x200
         )
 
     @property


### PR DESCRIPTION
Added the max_write_without_response_size to be the BLE MTU. Currently, this value is stored to comply with Bleak Characteristics but is unused on bless.