### PR TITLE
Ensure dbus object path is only valid chars

### DIFF
--- a/bless/backends/bluezdbus/dbus/application.py
+++ b/bless/backends/bluezdbus/dbus/application.py
@@ -1,3 +1,5 @@
+import re
+
 import bleak.backends.bluezdbus.defs as defs  # type: ignore
 
 from typing import List, Any, Callable, Optional, Union
@@ -45,7 +47,12 @@ class BlueZGattApplication(ServiceInterface):
         self.destination: str = destination
         self.bus: MessageBus = bus
 
-        self.base_path: str = "/org/bluez/" + self.app_name.replace(" ", "")
+        # Valid path must be ASCII characters "[A-Z][a-z][0-9]_"
+        # see https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-marshaling-object-path
+
+        self.base_path: str = (
+            "/org/bluez/" + re.sub( '[^A-Za-z0-9_]', '',  self.app_name )
+        )
         self.advertisements: List[BlueZLEAdvertisement] = []
         self.services: List[BlueZGattService] = []
 

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,12 @@ setuptools.setup(
     package_data={"bless": ["py.typed"]},
     packages=setuptools.find_packages(exclude=("test", "examples")),
     include_package_data=True,
+    dependency_links=[
+        "https://github.com/gwangyi/pysetupdi#egg=pysetupdi"
+    ],
     install_requires=[
         "bleak",
         "pywin32;platform_system=='Windows'",
-        "pysetupdi @ git+https://github.com/gwangyi/pysetupdi#egg=pysetupdi;platform_system=='Windows'"  # noqa: E501
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
The local name can be any utf-8 chars, but dbus requires a limited ASCII character set. 

dbus-next will validate paths to ensure they're `[A-Za-z0-9_]*`.

Fixes #126

