### PR TITLE
Support for python 3.12 on windows

### DIFF
--- a/bless/backends/winrt/characteristic.py
+++ b/bless/backends/winrt/characteristic.py
@@ -1,3 +1,4 @@
+import sys
 from uuid import UUID
 from typing import Union, Optional
 
@@ -5,12 +6,20 @@ from bleak.backends.winrt.characteristic import (  # type: ignore
     BleakGATTCharacteristicWinRT,
 )
 
-from bleak_winrt.windows.devices.bluetooth.genericattributeprofile import (  # type: ignore # noqa: E501
-    GattProtectionLevel,
-    GattLocalCharacteristicParameters,
-    GattLocalCharacteristic,
-    GattLocalCharacteristicResult,
-)
+if sys.version_info >= (3, 12):
+    from winrt.windows.devices.bluetooth.genericattributeprofile import (  # type: ignore # noqa: E501
+        GattProtectionLevel,
+        GattLocalCharacteristicParameters,
+        GattLocalCharacteristic,
+        GattLocalCharacteristicResult,
+    )
+else:
+    from bleak_winrt.windows.devices.bluetooth.genericattributeprofile import (  # type: ignore # noqa: E501
+        GattProtectionLevel,
+        GattLocalCharacteristicParameters,
+        GattLocalCharacteristic,
+        GattLocalCharacteristicResult,
+    )
 
 from bless.backends.service import BlessGATTService
 

--- a/bless/backends/winrt/server.py
+++ b/bless/backends/winrt/server.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 
+import sys
 from uuid import UUID
 from threading import Event
 from asyncio.events import AbstractEventLoop
@@ -24,22 +25,40 @@ from bless.backends.winrt.ble import BLEAdapter
 # from BleakBridge import Bridge
 
 # Import of other CLR components needed.
-from bleak_winrt.windows.foundation import Deferral  # type: ignore
+if sys.version_info >= (3, 12):
+    from winrt.windows.foundation import Deferral  # type: ignore
 
-from bleak_winrt.windows.storage.streams import DataReader, DataWriter  # type: ignore
+    from winrt.windows.storage.streams import DataReader, DataWriter  # type: ignore
 
-from bleak_winrt.windows.devices.bluetooth.genericattributeprofile import (  # type: ignore # noqa: E501
-    GattWriteOption,
-    GattServiceProvider,
-    GattLocalCharacteristic,
-    GattServiceProviderAdvertisingParameters,
-    GattServiceProviderAdvertisementStatusChangedEventArgs as StatusChangeEvent,  # noqa: E501
-    GattReadRequestedEventArgs,
-    GattReadRequest,
-    GattWriteRequestedEventArgs,
-    GattWriteRequest,
-    GattSubscribedClient,
-)
+    from winrt.windows.devices.bluetooth.genericattributeprofile import (  # type: ignore # noqa: E501
+        GattWriteOption,
+        GattServiceProvider,
+        GattLocalCharacteristic,
+        GattServiceProviderAdvertisingParameters,
+        GattServiceProviderAdvertisementStatusChangedEventArgs as StatusChangeEvent,  # noqa: E501
+        GattReadRequestedEventArgs,
+        GattReadRequest,
+        GattWriteRequestedEventArgs,
+        GattWriteRequest,
+        GattSubscribedClient,
+    )
+else:
+    from bleak_winrt.windows.foundation import Deferral  # type: ignore
+
+    from bleak_winrt.windows.storage.streams import DataReader, DataWriter  # type: ignore
+
+    from bleak_winrt.windows.devices.bluetooth.genericattributeprofile import (  # type: ignore # noqa: E501
+        GattWriteOption,
+        GattServiceProvider,
+        GattLocalCharacteristic,
+        GattServiceProviderAdvertisingParameters,
+        GattServiceProviderAdvertisementStatusChangedEventArgs as StatusChangeEvent,  # noqa: E501
+        GattReadRequestedEventArgs,
+        GattReadRequest,
+        GattWriteRequestedEventArgs,
+        GattWriteRequest,
+        GattSubscribedClient,
+    )
 
 logger = logging.getLogger(__name__)
 

--- a/bless/backends/winrt/service.py
+++ b/bless/backends/winrt/service.py
@@ -1,11 +1,18 @@
+import sys
 from uuid import UUID
 from typing import Union, cast, TYPE_CHECKING
-
-from bleak_winrt.windows.devices.bluetooth.genericattributeprofile import (  # type: ignore # noqa: E501
-    GattServiceProviderResult,
-    GattServiceProvider,
-    GattLocalService,
-)
+if sys.version_info >= (3, 12):
+    from winrt.windows.devices.bluetooth.genericattributeprofile import (  # type: ignore # noqa: E501
+        GattServiceProviderResult,
+        GattServiceProvider,
+        GattLocalService,
+    )
+else:
+    from bleak_winrt.windows.devices.bluetooth.genericattributeprofile import (  # type: ignore # noqa: E501
+        GattServiceProviderResult,
+        GattServiceProvider,
+        GattLocalService,
+    )
 
 from bleak.backends.winrt.service import BleakGATTServiceWinRT  # type: ignore
 from bless.backends.service import BlessGATTService

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,14 @@ setuptools.setup(
         "pywin32;platform_system=='Windows'",
         "dbus_next;platform_system=='Linux'",
         "pysetupdi @ git+https://github.com/gwangyi/pysetupdi#egg=pysetupdi;platform_system=='Windows'",  # noqa: E501
+        'bleak-winrt>=1.2.0; platform_system=="Windows" and python_version<"3.12"',
+        'winrt-Windows.Devices.Bluetooth==2.0.0b1; platform_system=="Windows" and python_version>="3.12"',
+        'winrt-Windows.Devices.Bluetooth.Advertisement==2.0.0b1; platform_system=="Windows" and python_version>="3.12"',
+        'winrt-Windows.Devices.Bluetooth.GenericAttributeProfile==2.0.0b1; platform_system=="Windows" and python_version>="3.12"',
+        'winrt-Windows.Devices.Enumeration==2.0.0b1; platform_system=="Windows" and python_version>="3.12"',
+        'winrt-Windows.Foundation==2.0.0b1; platform_system=="Windows" and python_version>="3.12"',
+        'winrt-Windows.Foundation.Collections==2.0.0b1; platform_system=="Windows" and python_version>="3.12"',
+        'winrt-Windows.Storage.Streams==2.0.0b1; platform_system=="Windows" and python_version>="3.12"',
     ],
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/test/backends/winrt/test_serviceprovider.py
+++ b/test/backends/winrt/test_serviceprovider.py
@@ -22,26 +22,46 @@ from bless.backends.characteristic import (  # type: ignore # noqa: E402
     GATTAttributePermissions,
 )
 
-from bleak_winrt.windows.foundation import Deferral  # type: ignore # noqa: E402 E501
+if sys.version_info >= (3, 12):
+    from winrt.windows.foundation import Deferral  # type: ignore # noqa: E402 E501
+    from winrt.windows.storage.streams import DataReader, DataWriter  # type: ignore # noqa: E402 E501
+    from winrt.windows.devices.bluetooth.genericattributeprofile import (  # type: ignore # noqa: E402 F401 E501
+        GattWriteOption,
+        GattServiceProviderResult,
+        GattServiceProvider,
+        GattLocalService,
+        GattLocalCharacteristicResult,
+        GattLocalCharacteristic,
+        GattLocalCharacteristicParameters,
+        GattServiceProviderAdvertisingParameters,
+        GattServiceProviderAdvertisementStatusChangedEventArgs,
+        GattReadRequestedEventArgs,
+        GattReadRequest,
+        GattWriteRequestedEventArgs,
+        GattWriteRequest,
+        GattSubscribedClient,
+    )
+else:
+    from bleak_winrt.windows.foundation import Deferral  # type: ignore # noqa: E402 E501
 
-from bleak_winrt.windows.storage.streams import DataReader, DataWriter  # type: ignore # noqa: E402 E501
+    from bleak_winrt.windows.storage.streams import DataReader, DataWriter  # type: ignore # noqa: E402 E501
 
-from bleak_winrt.windows.devices.bluetooth.genericattributeprofile import (  # type: ignore # noqa: E402 F401 E501
-    GattWriteOption,
-    GattServiceProviderResult,
-    GattServiceProvider,
-    GattLocalService,
-    GattLocalCharacteristicResult,
-    GattLocalCharacteristic,
-    GattLocalCharacteristicParameters,
-    GattServiceProviderAdvertisingParameters,
-    GattServiceProviderAdvertisementStatusChangedEventArgs,
-    GattReadRequestedEventArgs,
-    GattReadRequest,
-    GattWriteRequestedEventArgs,
-    GattWriteRequest,
-    GattSubscribedClient,
-)
+    from bleak_winrt.windows.devices.bluetooth.genericattributeprofile import (  # type: ignore # noqa: E402 F401 E501
+        GattWriteOption,
+        GattServiceProviderResult,
+        GattServiceProvider,
+        GattLocalService,
+        GattLocalCharacteristicResult,
+        GattLocalCharacteristic,
+        GattLocalCharacteristicParameters,
+        GattServiceProviderAdvertisingParameters,
+        GattServiceProviderAdvertisementStatusChangedEventArgs,
+        GattReadRequestedEventArgs,
+        GattReadRequest,
+        GattWriteRequestedEventArgs,
+        GattWriteRequest,
+        GattSubscribedClient,
+    )
 
 
 @hardware_only


### PR DESCRIPTION
Switched to pywinrt because bleak-winrt is no supported since python 3.12.
https://github.com/dlech/bleak-winrt/pull/5#issuecomment-2004979086