### PR TITLE
Encrypted Read/Write Support for Linux

### DIFF
--- a/test/backends/test_server.py
+++ b/test/backends/test_server.py
@@ -2,6 +2,7 @@ import sys
 import uuid
 import pytest
 import asyncio
+import os
 import aioconsole  # type: ignore
 
 import numpy as np  # type: ignore
@@ -26,6 +27,7 @@ from bless.backends.characteristic import (  # noqa: E402
         )
 
 hardware_only = pytest.mark.skipif("os.environ.get('TEST_HARDWARE') is None")
+use_encrypted = os.environ.get('TEST_ENCRYPTED') is not None
 
 
 @hardware_only
@@ -83,6 +85,13 @@ class TestBlessServer:
                 GATTAttributePermissions.readable |
                 GATTAttributePermissions.writeable
                 )
+        
+        if use_encrypted:
+            print("\nEncryption has been enabled, ensure that you are bonded")
+            permissions = (
+                    GATTAttributePermissions.read_encryption_required |
+                    GATTAttributePermissions.write_encryption_required
+                    )
 
         await server.add_new_characteristic(
                 service_uuid,


### PR DESCRIPTION
Added functionality to enable encryption in the bluez backend, addressing #115.  Additionally updated test_server to rudimentarily allow for the testing of encrypted read/write with use of an environment variable.

Notes regarding testing:
- I tested this on a Pixel 7a running Android 14 using LightBlue.
- If the "READ AGAIN" button is pressed _before_ the phone is paired to the server device, the phone will prompt the user to pair with the server.  The test will then proceed normally if paired, however it will fail the assertion on line 168.
- If the "READ AGAIN" button is pressed _after_ the phone is paired to the server device, the test will proceed normally and the assertion on line 168 will pass.