### PR TITLE
Allow to define descriptor for GATT characteristic

### DIFF
--- a/bless/__init__.py
+++ b/bless/__init__.py
@@ -35,6 +35,11 @@ elif sys.platform == "linux":
         BlessGATTCharacteristicBlueZDBus as BlessGATTCharacteristic,
     )
 
+    # Descriptor Classes
+    from bless.backends.bluezdbus.descriptor import (  # noqa: F401
+        BlessGATTDescriptorBlueZDBus as BlessGATTDescriptor,
+    )
+
 elif sys.platform == "win32":
 
     # Server
@@ -52,11 +57,19 @@ elif sys.platform == "win32":
         BlessGATTCharacteristicWinRT as BlessGATTCharacteristic,
     )
 
+# type: ignore
+from bless.backends.attribute import (  # noqa: E402 F401
+    GATTAttributePermissions,
+)
 
 # type: ignore
 from bless.backends.characteristic import (  # noqa: E402 F401
     GATTCharacteristicProperties,
-    GATTAttributePermissions,
+)
+
+# type: ignore
+from bless.backends.descriptor import (  # noqa: E402 F401
+    GATTDescriptorProperties,
 )
 
 

--- a/bless/backends/attribute.py
+++ b/bless/backends/attribute.py
@@ -1,0 +1,7 @@
+from enum import Flag
+
+class GATTAttributePermissions(Flag):
+    readable = 0x1
+    writeable = 0x2
+    read_encryption_required = 0x4
+    write_encryption_required = 0x8

--- a/bless/backends/bluezdbus/characteristic.py
+++ b/bless/backends/bluezdbus/characteristic.py
@@ -8,6 +8,7 @@ else:
 
 from typing import Union, Optional, List, Dict, cast, TYPE_CHECKING
 
+from bless.backends.bluezdbus.descriptor import BlessGATTDescriptorBlueZDBus
 from bleak.backends.bluezdbus.characteristic import (  # type: ignore
     _GattCharacteristicsFlagsEnum,
     BleakGATTCharacteristicBlueZDBus,
@@ -19,10 +20,12 @@ if TYPE_CHECKING:
     from bless.backends.bluezdbus.service import BlessGATTServiceBlueZDBus
     from bless.backends.service import BlessGATTService
 
+from bless.backends.attribute import (  # type: ignore
+    GATTAttributePermissions,
+)
 from bless.backends.characteristic import (  # noqa: E402
     BlessGATTCharacteristic,
     GATTCharacteristicProperties,
-    GATTAttributePermissions,
 )
 
 from bless.backends.bluezdbus.dbus.characteristic import (  # noqa: E402
@@ -63,6 +66,7 @@ class BlessGATTCharacteristicBlueZDBus(
         """
         value = value if value is not None else bytearray(b"")
         super().__init__(uuid, properties, permissions, value)
+        self.__descriptors: List[BlessGATTDescriptorBlueZDBus] = []
         self.value = value
 
     async def init(self, service: "BlessGATTService"):
@@ -117,6 +121,20 @@ class BlessGATTCharacteristicBlueZDBus(
     def uuid(self) -> str:
         """The uuid of this characteristic"""
         return self.obj.get("UUID").value
+
+    @property
+    def descriptors(self) -> List[BlessGATTDescriptorBlueZDBus]:  # type: ignore
+        """List of characteristics for this service"""
+        return self.__descriptors
+
+    def add_descriptor(  # type: ignore
+        self,
+        descriptor: BlessGATTDescriptorBlueZDBus
+    ):
+        """
+        Should not be used by end user, but rather by `bleak` itself.
+        """
+        self.__descriptors.append(descriptor)
 
 def transform_flags_with_permissions(flag: Flags, permissions: GATTAttributePermissions) -> Flags:
     """

--- a/bless/backends/bluezdbus/dbus/characteristic.py
+++ b/bless/backends/bluezdbus/dbus/characteristic.py
@@ -2,16 +2,17 @@ from enum import Enum
 
 import bleak.backends.bluezdbus.defs as defs  # type: ignore
 
-from typing import List, Dict, TYPE_CHECKING
+from typing import List, TYPE_CHECKING, Any, Dict
 
 from dbus_next.service import ServiceInterface, method, dbus_property  # type: ignore
 from dbus_next.constants import PropertyAccess  # type: ignore
 from dbus_next.signature import Variant  # type: ignore
 
+from .descriptor import BlueZGattDescriptor, DescriptorFlags  # type: ignore
+
 if TYPE_CHECKING:
     from bless.backends.bluezdbus.dbus.service import (  # type: ignore # noqa: F401
-        BlueZGattService,
-        BlueZGattDescriptor
+        BlueZGattService
     )
 
 
@@ -162,6 +163,31 @@ class BlueZGattCharacteristic(ServiceInterface):
             raise NotImplementedError()
         f(None)
         self._service.app.subscribed_characteristics.remove(self._uuid)
+
+    async def add_descriptor(
+        self, uuid: str, flags: List[DescriptorFlags], value: Any
+    ) -> BlueZGattDescriptor:
+        """
+        Adds a BlueZGattDescriptor to the characteristic.
+
+        Parameters
+        ----------
+        uuid : str
+            The string representation of the UUID for the descriptor
+        flags : List[DescriptorFlags],
+            A list of flags to apply to the descriptor
+        value : Any
+            The descriptor's value
+        """
+        index: int = len(self.descriptors) + 1
+        descriptor: BlueZGattDescriptor = BlueZGattDescriptor(
+            uuid, flags, index, self
+        )
+        descriptor._value = value  # type: ignore
+        self.descriptors.append(descriptor)
+        await self._service.app._register_object(descriptor)
+        return descriptor
+
 
     async def get_obj(self) -> Dict:
         """

--- a/bless/backends/bluezdbus/dbus/descriptor.py
+++ b/bless/backends/bluezdbus/dbus/descriptor.py
@@ -1,0 +1,134 @@
+from enum import Enum
+
+import bleak.backends.bluezdbus.defs as defs  # type: ignore
+
+from typing import List, Dict, TYPE_CHECKING
+
+from dbus_next.service import ServiceInterface, method, dbus_property  # type: ignore
+from dbus_next.constants import PropertyAccess  # type: ignore
+from dbus_next.signature import Variant  # type: ignore
+
+if TYPE_CHECKING:
+    from bless.backends.bluezdbus.dbus.characteristic import (  # type: ignore # noqa: F401
+        BlueZGattCharacteristic
+    )
+
+
+class DescriptorFlags(Enum):
+    READ = "read"
+    WRITE = "write"
+    ENCRYPT_READ = "encrypt-read"
+    ENCRYPT_WRITE = "encrypt-write"
+    ENCRYPT_AUTHENTICATED_READ = "encrypt-authenticated-read"
+    ENCRYPT_AUTHENTICATED_WRITE = "encrypt-authenticated-write"
+    AUTHORIZE = "authorize"
+
+
+class BlueZGattDescriptor(ServiceInterface):
+    """
+    org.bluez.GattDescriptor1 interface implementation
+    """
+
+    interface_name: str = defs.GATT_DESCRIPTOR_INTERFACE
+
+    def __init__(
+        self,
+        uuid: str,
+        flags: List[DescriptorFlags],
+        index: int,
+        characteristic: "BlueZGattCharacteristic",  # noqa: F821
+    ):
+        """
+        Create a BlueZ Gatt Descriptor
+
+        Parameters
+        ----------
+        uuid : str
+            The unique identifier for the descriptor
+        flags : List[DescriptorFlags]
+            A list of strings that represent the properties of the
+            descriptor
+        index : int
+            The index number for this descriptor in the descriptors
+        characteristic : BlueZService
+            The Gatt Characteristic that owns this descriptor
+        """
+        self.path: str = characteristic.path + "/desc" + f"{index:04d}"
+        self._uuid: str = uuid
+        self._flags: List[str] = [x.value for x in flags]
+        self._characteristic_path: str = characteristic.path  # noqa: F821
+        self._characteristic: "BlueZGattCharacteristic" = characteristic  # noqa: F821
+
+        self._value: bytes = b""
+
+        super(BlueZGattDescriptor, self).__init__(self.interface_name)
+
+    @dbus_property(access=PropertyAccess.READ)
+    def UUID(self) -> "s":  # type: ignore # noqa: F821 N802
+        return self._uuid
+
+    @dbus_property(access=PropertyAccess.READ)
+    def Characteristic(self) -> "o":  # type: ignore # noqa: F821 N802
+        return self._characteristic_path
+
+    @dbus_property()
+    def Value(self) -> "ay":  # type: ignore # noqa: F821 N802
+        return self._value
+
+    @Value.setter  # type: ignore
+    def Value(self, value: "ay"):  # type: ignore # noqa: F821 N802
+        self._value = value
+        self.emit_properties_changed(
+            changed_properties={"Value": self._value}
+        )
+
+    @dbus_property(access=PropertyAccess.READ)  # noqa: F722
+    def Flags(self) -> "as":  # type: ignore # noqa: F821 F722 N802
+        return self._flags
+
+    @method()  # noqa: F722
+    def ReadValue(self, options: "a{sv}") -> "ay":  # type: ignore # noqa: F722 F821 N802 E501
+        """
+        Read the value of the descriptor.
+        This is to be fully implemented at the application level
+
+        Parameters
+        ----------
+        options : Dict
+            A list of options
+
+        Returns
+        -------
+        bytes
+            The bytes that is the value of the descriptor
+        """
+        return self._value
+
+    @method()  # noqa: F722
+    def WriteValue(self, value: "ay", options: "a{sv}"):  # type: ignore # noqa
+        """
+        Write a value to the descriptor
+        This is to be fully implemented at the application level
+
+        Parameters
+        ----------
+        value : bytes
+            The value to set
+        options : Dict
+            Some options for you to select from
+        """
+        self._value = value
+
+    async def get_obj(self) -> Dict:
+        """
+        Obtain the underlying dictionary within the BlueZ API that describes
+        the descriptor
+
+        Returns
+        -------
+        Dict
+            The dictionary that describes the descriptor
+        """
+        return {
+            "UUID": Variant('s', self._uuid)
+        }

--- a/bless/backends/bluezdbus/descriptor.py
+++ b/bless/backends/bluezdbus/descriptor.py
@@ -1,0 +1,201 @@
+import sys
+from uuid import UUID
+
+if sys.version_info[:2] < (3, 8):
+    from typing_extensions import Literal
+else:
+    from typing import Literal
+
+from typing import Union, Optional, List, Dict, cast, TYPE_CHECKING
+
+from bleak.backends.bluezdbus.descriptor import (  # type: ignore
+    BleakGATTDescriptorBlueZDBus,
+)
+
+from bleak.backends.bluezdbus.defs import GattDescriptor1
+
+if TYPE_CHECKING:
+    from bless.backends.bluezdbus.characteristic import BlessGATTCharacteristicBlueZDBus
+    from bless.backends.characteristic import BlessGATTCharacteristic
+
+from bless.backends.attribute import (  # noqa: E402
+    GATTAttributePermissions,
+)
+
+from bless.backends.descriptor import (  # noqa: E402
+    BlessGATTDescriptor,
+    GATTDescriptorProperties,
+)
+
+from bless.backends.bluezdbus.dbus.descriptor import (  # noqa: E402
+    DescriptorFlags,
+    BlueZGattDescriptor,
+)
+
+
+_GATTDescriptorsFlagsEnum = {
+    0x0001: "read",
+    0x0002: "write",
+    # "encrypt-read"
+    # "encrypt-write"
+    # "encrypt-authenticated-read"
+    # "encrypt-authenticated-write"
+    # "secure-read" #(Server only)
+    # "secure-write" #(Server only)
+    # "authorize"
+}
+
+
+class BlessGATTDescriptorBlueZDBus(
+    BlessGATTDescriptor, BleakGATTDescriptorBlueZDBus
+):
+    """
+    BlueZ implementation of the BlessGATTDescriptor
+    """
+
+    def __init__(
+        self,
+        uuid: Union[str, UUID],
+        properties: GATTDescriptorProperties,
+        permissions: GATTAttributePermissions,
+        value: Optional[bytearray],
+    ):
+        """
+        Instantiates a new GATT Characteristic but is not yet assigned to any
+        service or application
+
+        Parameters
+        ----------
+        uuid : Union[str, UUID]
+            The string representation of the universal unique identifier for
+            the characteristic or the actual UUID object
+        properties : GATTDescriptorProperties
+            The properties that define the characteristics behavior
+        permissions : GATTAttributePermissions
+            Permissions that define the protection levels of the properties
+        value : Optional[bytearray]
+            The binary value of the characteristic
+        """
+        value = value if value is not None else bytearray(b"")
+        super().__init__(uuid, properties, permissions, value)
+        self.value = value
+
+    async def init(self, characteristic: "BlessGATTCharacteristic"):
+        """
+        Initialize the BlueZGattDescriptor object
+
+        Parameters
+        ----------
+        characteristic : BlessGATTCharacteristic
+            The characteristic to assign the descriptor to
+        """
+        flags: List[DescriptorFlags] = [transform_flags_with_permissions(f, self._permissions) for f in  flags_to_dbus(self._properties)]
+
+        # Add to our BlueZDBus app
+        bluez_characteristic: "BlessGATTCharacteristicBlueZDBus" = cast(
+            "BlessGATTCharacteristicBlueZDBus", characteristic
+        )
+        gatt_desc: BlueZGattDescriptor = (
+            await bluez_characteristic.gatt.add_descriptor(
+                self._uuid, flags, bytes(self.value)
+            )
+        )
+        dict_obj: Dict = await gatt_desc.get_obj()
+        obj: GattDescriptor1 = GattDescriptor1(
+            UUID=dict_obj["UUID"],
+            Characteristic=characteristic.uuid,
+            Value=bytes(self.value),
+            Flags=cast(_Flags, flags),
+        )
+
+        # Add a Bleak Characteristic properties
+        self.gatt = gatt_desc
+        super(BlessGATTDescriptor, self).__init__(
+            obj, gatt_desc.path, characteristic.uuid, 0
+        )
+
+    @property
+    def value(self) -> bytearray:
+        """Get the value of the characteristic"""
+        return bytearray(self._value)
+
+    @value.setter
+    def value(self, val: bytearray):
+        """Set the value of the characteristic"""
+        self._value = val
+
+    @property
+    def uuid(self) -> str:
+        """The uuid of this characteristic"""
+        return self.obj.get("UUID").value
+
+def transform_flags_with_permissions(flag: DescriptorFlags, permissions: GATTAttributePermissions) -> DescriptorFlags:
+    """
+    Returns the encrypted variant of a flag if the corresponding permission is set
+
+    Parameters
+    ----------
+    flag : GATTDescriptorProperties
+        The numerical enumeration of a single flag
+    
+    permissions: GATTAttributePermissions
+        The permissions for the characteristic
+
+    Returns
+    -------
+    List[DescriptorFlags]
+        A Flags enum value for use in BlueZDBus that has been updated to reflect if it should be encrypted
+    """
+    if flag == DescriptorFlags.READ and GATTAttributePermissions.read_encryption_required in permissions:
+        return DescriptorFlags.ENCRYPT_READ
+    elif flag == DescriptorFlags.WRITE and GATTAttributePermissions.write_encryption_required in permissions:
+        return DescriptorFlags.ENCRYPT_WRITE
+    
+    return flag
+
+def flags_to_dbus(flags: GATTDescriptorProperties) -> List[DescriptorFlags]:
+    """
+    Convert Bleak/Bless flags
+
+    Parameters
+    ----------
+    flags : GATTDescriptorProperties
+        The numerical enumeration for the combined flags
+
+    Returns
+    -------
+    List[DescriptorFlags]
+        A list fo Flags for use in BlueZDBus
+    """
+    result: List[DescriptorFlags] = []
+    flag_value: int = flags.value
+    for i, int_flag in enumerate(_GATTDescriptorsFlagsEnum.keys()):
+        included: bool = int_flag & flag_value > 0
+        if included:
+            flag_enum_val: str = _GATTDescriptorsFlagsEnum[int_flag]
+            flag: DescriptorFlags = next(
+                iter(
+                    [
+                        DescriptorFlags.__members__[x]
+                        for x in list(DescriptorFlags.__members__)
+                        if DescriptorFlags.__members__[x].value == flag_enum_val
+                    ]
+                )
+            )
+            result.append(flag)
+
+    return result
+
+
+_Flags = List[
+    Literal[
+        "read",
+        "write",
+        "encrypt-read",
+        "encrypt-write",
+        "encrypt-authenticated-read",
+        "encrypt-authenticated-write",
+        # "secure-read" and "secure-write" are server-only and not available in Bleak
+        "authorize",
+    ]
+]

--- a/bless/backends/characteristic.py
+++ b/bless/backends/characteristic.py
@@ -9,6 +9,7 @@ from bleak.backends.characteristic import BleakGATTCharacteristic  # type: ignor
 from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from bless.backends.service import BlessGATTService
+    from bless.backends.descriptor import BlessGATTDescriptor
 
 
 class GATTCharacteristicProperties(Flag):
@@ -24,11 +25,7 @@ class GATTCharacteristicProperties(Flag):
     writable_auxiliaries = 0x0200
 
 
-class GATTAttributePermissions(Flag):
-    readable = 0x1
-    writeable = 0x2
-    read_encryption_required = 0x4
-    write_encryption_required = 0x8
+from .attribute import GATTAttributePermissions
 
 
 class BlessGATTCharacteristic(BleakGATTCharacteristic):
@@ -92,3 +89,7 @@ class BlessGATTCharacteristic(BleakGATTCharacteristic):
     def value(self, val: bytearray):
         """Set the value of this characteristic"""
         raise NotImplementedError()
+
+    def get_descriptor(self, uuid: Union[str, UUID]) -> "BlessGATTDescriptor":
+        """Get a descriptor by UUID (str or uuid.UUID)"""
+        return cast("BlessGATTDescriptor", super().get_descriptor(uuid))

--- a/bless/backends/corebluetooth/characteristic.py
+++ b/bless/backends/corebluetooth/characteristic.py
@@ -10,9 +10,12 @@ from bleak.backends.corebluetooth.characteristic import (  # type: ignore
 
 from bless.backends.service import BlessGATTService
 
+from bless.backends.attribute import (
+    GATTAttributePermissions,
+)
+
 from bless.backends.characteristic import (
     GATTCharacteristicProperties,
-    GATTAttributePermissions,
     BlessGATTCharacteristic,
 )
 

--- a/bless/backends/corebluetooth/server.py
+++ b/bless/backends/corebluetooth/server.py
@@ -22,9 +22,11 @@ from bless.backends.corebluetooth.service import BlessGATTServiceCoreBluetooth
 from bless.backends.corebluetooth.characteristic import (  # type: ignore
     BlessGATTCharacteristicCoreBluetooth,
 )
+from bless.backends.attribute import (
+    GATTAttributePermissions,
+)
 from bless.backends.characteristic import (
     GATTCharacteristicProperties,
-    GATTAttributePermissions,
 )
 
 

--- a/bless/backends/descriptor.py
+++ b/bless/backends/descriptor.py
@@ -1,0 +1,88 @@
+import abc
+
+from enum import Flag
+from uuid import UUID
+from typing import Union, Optional, cast
+
+from bleak.backends.descriptor import BleakGATTDescriptor  # type: ignore
+
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from bless.backends.characteristic import BlessGATTCharacteristic
+
+class GATTDescriptorProperties(Flag):
+    read = 0x0001
+    write = 0x0002
+    # encrypt_read = 0x0004
+    # encrypt_write = 0x0008
+    # encrypt_authenticated_read = 0x0010
+    # encrypt_authenticated_write = 0x0020
+    # secure_read = 0x0040
+    # secure_write = 0x0080
+    # authorize = 0x0100
+
+
+from .attribute import GATTAttributePermissions
+
+
+class BlessGATTDescriptor(BleakGATTDescriptor):
+    """
+    Extension of the BleakGATTDescriptor to allow for writeable values
+    """
+
+    def __init__(
+        self,
+        uuid: Union[str, UUID],
+        properties: GATTDescriptorProperties,
+        permissions: GATTAttributePermissions,
+        value: Optional[bytearray]
+    ):
+        """
+        Instantiates a new GATT Descriptor but is not yet assigned to any
+        characteristic or application
+
+        Parameters
+        ----------
+        uuid : Union[str, UUID]
+            The string representation of the universal unique identifier for
+            the descriptor or the actual UUID object
+        properties : GATTDescriptorProperties
+            The properties that define the descriptors behavior
+        permissions : GATTAttributePermissions
+            Permissions that define the protection levels of the properties
+        value : Optional[bytearray]
+            The binary value of the descriptor
+        """
+        if type(uuid) is str:
+            uuid_str: str = cast(str, uuid)
+            uuid = UUID(uuid_str)
+        self._uuid: str = str(uuid)
+        self._properties: GATTDescriptorProperties = properties
+        self._permissions: GATTAttributePermissions = permissions
+        self._initial_value: Optional[bytearray] = value
+
+    def __str__(self):
+        """
+        String output of this descriptor
+        """
+        return f"{self.uuid}: {self.description}"
+
+    @abc.abstractmethod
+    async def init(self, characteristic: "BlessGATTCharacteristic"):
+        """
+        Initializes the backend-specific descriptor object and stores it in
+        self.obj
+        """
+        raise NotImplementedError()
+
+    @property  # type: ignore
+    @abc.abstractmethod
+    def value(self) -> bytearray:
+        """Value of this descriptor"""
+        raise NotImplementedError()
+
+    @value.setter  # type: ignore
+    @abc.abstractmethod
+    def value(self, val: bytearray):
+        """Set the value of this descriptor"""
+        raise NotImplementedError()

--- a/bless/backends/server.py
+++ b/bless/backends/server.py
@@ -7,10 +7,15 @@ from asyncio import AbstractEventLoop
 from typing import Any, Optional, Dict, Callable, List
 
 from bless.backends.service import BlessGATTService
+from bless.backends.attribute import (  # type: ignore
+    GATTAttributePermissions
+)
 from bless.backends.characteristic import (  # type: ignore
     BlessGATTCharacteristic,
-    GATTCharacteristicProperties,
-    GATTAttributePermissions
+    GATTCharacteristicProperties
+)
+from bless.backends.descriptor import (  # type: ignore
+    GATTDescriptorProperties
 )
 
 from bless.exceptions import BlessError
@@ -136,6 +141,39 @@ class BaseBlessServer(abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
+    async def add_new_descriptor(
+        self,
+        service_uuid: str,
+        char_uuid: str,
+        desc_uuid: str,
+        properties: GATTDescriptorProperties,
+        value: Optional[bytearray],
+        permissions: GATTAttributePermissions,
+    ):
+        """
+        Add a new characteristic to be associated with the server
+
+        Parameters
+        ----------
+        service_uuid : str
+            The string representation of the UUID of the GATT service to which
+            this existing characteristic belongs
+        char_uuid : str
+            The string representation of the UUID of the GATT characteristic
+            to which this new descriptor should belong
+        desc_uuid : str
+            The string representation of the UUID of the descriptor
+        properties : GATTDescriptorProperties
+            GATT Characteristic Flags that define the descriptor
+        value : Optional[bytearray]
+            A byterray representation of the value to be associated with the
+            descriptor. Can be None if the descriptor is writable
+        permissions : GATTAttributePermissions
+            GATT flags that define the permissions for the descriptor
+        """
+        raise NotImplementedError()
+
+    @abc.abstractmethod
     def update_value(self, service_uuid: str, char_uuid: str) -> bool:
         """
         Update the characteristic value. This is different than using
@@ -225,8 +263,17 @@ class BaseBlessServer(abc.ABC):
                         service_uuid, char_uuid, char_info.get("Properties"),
                         char_info.get("Value"), char_info.get("Permissions")
                         )
+                descriptors = char_info.get("Descriptors")
+                if isinstance(descriptors, dict):
+                    for desc_uuid, desc_info in descriptors.items():
+                        await self.add_new_descriptor(
+                                service_uuid, char_uuid, desc_uuid,
+                                desc_info.get("Properties"),
+                                desc_info.get("Value"),
+                                desc_info.get("Permissions")
+                                )
 
-    def read_request(self, uuid: str) -> bytearray:
+    def read_request(self, uuid: str, options: Dict) -> bytearray:
         """
         This function should be handed off to the subsequent backend bluetooth
         servers as a callback for incoming read requests on values for

--- a/bless/backends/winrt/characteristic.py
+++ b/bless/backends/winrt/characteristic.py
@@ -23,10 +23,13 @@ else:
 
 from bless.backends.service import BlessGATTService
 
+from bless.backends.attribute import (
+    GATTAttributePermissions,
+)
+
 from bless.backends.characteristic import (
     BlessGATTCharacteristic,
     GATTCharacteristicProperties,
-    GATTAttributePermissions,
 )
 
 

--- a/bless/backends/winrt/server.py
+++ b/bless/backends/winrt/server.py
@@ -8,9 +8,11 @@ from asyncio.events import AbstractEventLoop
 from typing import Optional, List, Any, cast
 
 from bless.backends.server import BaseBlessServer  # type: ignore
+from bless.backends.attribute import (  # type: ignore
+    GATTAttributePermissions,
+)
 from bless.backends.characteristic import (  # type: ignore
     GATTCharacteristicProperties,
-    GATTAttributePermissions,
 )
 from bless.backends.winrt.service import BlessGATTServiceWinRT
 from bless.backends.winrt.characteristic import (  # type: ignore

--- a/test/backends/test_server.py
+++ b/test/backends/test_server.py
@@ -21,9 +21,11 @@ if sys.platform not in ['darwin', 'linux', 'win32']:
             )
 
 from bless import BlessServer  # type: ignore  # noqa: E402
+from bless.backends.attribute import (  # noqa: E402
+        GATTAttributePermissions,
+        )
 from bless.backends.characteristic import (  # noqa: E402
         GATTCharacteristicProperties,
-        GATTAttributePermissions
         )
 
 hardware_only = pytest.mark.skipif("os.environ.get('TEST_HARDWARE') is None")

--- a/test/backends/winrt/test_serviceprovider.py
+++ b/test/backends/winrt/test_serviceprovider.py
@@ -17,9 +17,12 @@ from typing import List, Any  # noqa: E402
 
 hardware_only = pytest.mark.skipif("os.environ.get('TEST_HARDWARE') is None")
 
+from bless.backends.attribute import (  # type: ignore # noqa: E402
+    GATTAttributePermissions,
+)
+
 from bless.backends.characteristic import (  # type: ignore # noqa: E402
     GATTCharacteristicProperties,
-    GATTAttributePermissions,
 )
 
 if sys.version_info >= (3, 12):


### PR DESCRIPTION
First implementation for Descriptor in linux.
Tested as working feature on Raspberry 4.

Feel free to review and comment.

I noticed that bless library does not expand the uuid from 16 bit and 32 bit form.
I put a proposal to use normalize_uuid_str to expand uuid to full value.