### PR TITLE
Constrain bleak dependency version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=("test", "examples")),
     include_package_data=True,
     install_requires=[
-        "bleak",
+        "bleak>=0.22.3,<1.0.0",
         "pywin32;platform_system=='Windows'",
         "dbus_next;platform_system=='Linux'",
         "pysetupdi @ git+https://github.com/gwangyi/pysetupdi#egg=pysetupdi;platform_system=='Windows'",  # noqa: E501


### PR DESCRIPTION
Version 1.0.0 breaks bless

Related to #150, but a better solution would be to update bless to work with the newer version of bleak.