### PR TITLE
Expose MTU onto the peripheral server

### DIFF
--- a/bless/backends/bluezdbus/dbus/application.py
+++ b/bless/backends/bluezdbus/dbus/application.py
@@ -2,7 +2,7 @@ import re
 
 import bleak.backends.bluezdbus.defs as defs  # type: ignore
 
-from typing import List, Any, Callable, Optional, Union
+from typing import List, Any, Callable, Optional, Union, Dict
 
 from dbus_next.aio import MessageBus, ProxyObject, ProxyInterface  # type: ignore
 from dbus_next.service import ServiceInterface  # type: ignore
@@ -51,8 +51,12 @@ class BlueZGattApplication(ServiceInterface):
         self.advertisements: List[BlueZLEAdvertisement] = []
         self.services: List[BlueZGattService] = []
 
-        self.Read: Optional[Callable[[BlueZGattCharacteristic], bytes]] = None
-        self.Write: Optional[Callable[[BlueZGattCharacteristic, bytes], None]] = None
+        self.Read: Optional[
+            Callable[[BlueZGattCharacteristic, Dict[str, Any]], bytes]
+        ] = None
+        self.Write: Optional[
+            Callable[[BlueZGattCharacteristic, bytes, Dict[str, Any]], None]
+        ] = None
         self.StartNotify: Optional[Callable[[None], None]] = None
         self.StopNotify: Optional[Callable[[None], None]] = None
 

--- a/bless/backends/bluezdbus/dbus/characteristic.py
+++ b/bless/backends/bluezdbus/dbus/characteristic.py
@@ -122,7 +122,7 @@ class BlueZGattCharacteristic(ServiceInterface):
         f = self._service.app.Read
         if f is None:
             raise NotImplementedError()
-        return f(self)
+        return f(self, options)
 
     @method()  # noqa: F722
     def WriteValue(self, value: "ay", options: "a{sv}"):  # type: ignore # noqa
@@ -140,7 +140,7 @@ class BlueZGattCharacteristic(ServiceInterface):
         f = self._service.app.Write
         if f is None:
             raise NotImplementedError()
-        f(self, value)
+        f(self, value, options)
 
     @method()
     def StartNotify(self):  # noqa: N802

--- a/bless/backends/bluezdbus/server.py
+++ b/bless/backends/bluezdbus/server.py
@@ -2,7 +2,7 @@ import asyncio
 
 from uuid import UUID
 
-from typing import Any, Optional, cast
+from typing import Any, Optional, cast, Dict
 
 from asyncio import AbstractEventLoop
 
@@ -296,7 +296,7 @@ class BlessServerBlueZDBus(BaseBlessServer):
         characteristic.Value = bytes(cur_value)  # type: ignore
         return True
 
-    def read(self, char: BlueZGattCharacteristic) -> bytes:
+    def read(self, char: BlueZGattCharacteristic, options: Dict[str, Any]) -> bytes:
         """
         Read request.
         This re-routes the the request incomming on the dbus to the server to
@@ -314,9 +314,11 @@ class BlessServerBlueZDBus(BaseBlessServer):
         bytes
             The value of the characteristic
         """
-        return bytes(self.read_request(char.UUID, {}))
+        return bytes(self.read_request(char.UUID, options))
 
-    def write(self, char: BlueZGattCharacteristic, value: bytes):
+    def write(
+        self, char: BlueZGattCharacteristic, value: bytes, options: Dict[str, Any]
+    ):
         """
         Write request.
         This function re-routes the write request sent from the
@@ -330,4 +332,4 @@ class BlessServerBlueZDBus(BaseBlessServer):
         value : bytearray
             The value being requested to set
         """
-        return self.write_request(char.UUID, bytearray(value))
+        return self.write_request(char.UUID, bytearray(value), options)

--- a/bless/backends/corebluetooth/peripheral_manager_delegate.py
+++ b/bless/backends/corebluetooth/peripheral_manager_delegate.py
@@ -10,6 +10,7 @@ if TYPE_CHECKING:
         _advertisement_started_event: Any
         _services_added_events: Dict[str, Any]
         _central_subscriptions: Dict[str, Any]
+        server: Optional[Any]
         pyobjc_classMethods: Any
 
         @classmethod
@@ -98,6 +99,7 @@ else:
             self = objc.super(PeripheralManagerDelegate, self).init()
 
             self.event_loop: Optional[asyncio.AbstractEventLoop] = None
+            self.server: Optional[Any] = None
 
             self.peripheral_manager: CBPeripheralManager = (
                 CBPeripheralManager.alloc().initWithDelegate_queue_(
@@ -342,6 +344,14 @@ else:
                     central_uuid, char_uuid
                 )
             )
+            mtu_value = None
+            max_update = getattr(central, "maximumUpdateValueLength", None)
+            if callable(max_update):
+                mtu_value = max_update()
+            else:
+                mtu_value = max_update
+            if mtu_value is not None and self.server is not None:
+                self.server._mtu = int(mtu_value)
             if central_uuid in self._central_subscriptions:
                 subscriptions = self._central_subscriptions[central_uuid]
                 if char_uuid not in subscriptions:

--- a/bless/backends/corebluetooth/server.py
+++ b/bless/backends/corebluetooth/server.py
@@ -69,6 +69,7 @@ class BlessServerCoreBluetooth(BaseBlessServer):
         self.peripheral_manager_delegate: PeripheralManagerDelegate = (
             PeripheralManagerDelegate.alloc().init()
         )
+        self.peripheral_manager_delegate.server = self
         self.peripheral_manager_delegate.read_request_func = self.read_request
         self.peripheral_manager_delegate.write_request_func = self.write_request
 

--- a/bless/backends/winrt/server.py
+++ b/bless/backends/winrt/server.py
@@ -444,4 +444,12 @@ class BlessServerWinRT(BaseBlessServer):
         """
         clients = sender.subscribed_clients
         self._subscribed_clients = list(clients) if clients is not None else []
+        if self._subscribed_clients:
+            mtu_values = [
+                int(client.max_pdu_size)
+                for client in self._subscribed_clients
+                if getattr(client, "max_pdu_size", None) is not None
+            ]
+            if mtu_values:
+                self._mtu = max(mtu_values)
         logger.info("New device subscribed")


### PR DESCRIPTION
This is really a brute force and odd approach to the solution. Each backend obtains the MTU differently, and because data transfers are often initiated by the central, the MTU will default to None until some action is taken. On windows and MacOS, that action must be a subscription to a characteristic so that the MTU can be negotiated and exposed. On Linux, it is updated every read and write request.