### PR TITLE
121 friendlier warning if bluez is not installed on linux

### DIFF
--- a/bless/backends/bluezdbus/dbus/application.py
+++ b/bless/backends/bluezdbus/dbus/application.py
@@ -80,7 +80,9 @@ class BlueZGattApplication(ServiceInterface):
             return
         message = (
             "BlueZ utilities not found (bluetoothd/bluetoothctl). "
-            "Install BlueZ to use the Linux backend."
+            "Install BlueZ to use the Linux backend. On Debian/Ubuntu: "
+            "`sudo apt-get install bluez`. On Raspberry Pi, you may also want "
+            "`pi-bluetooth`."
         )
         warnings.warn(message, RuntimeWarning)
         LOGGER.warning(message)


### PR DESCRIPTION
These changes simply include a friendly error message when BlueZ is not found on a linux installation