### PR TITLE
build: remove the egg syntax from pysetupdi dep in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setuptools.setup(
         "pywin32;platform_system=='Windows'",
         "dbus_next;platform_system=='Linux'",
         (
-            "pysetupdi @ git+https://github.com/gwangyi/pysetupdi#egg=pysetupdi;"
+            "pysetupdi @ git+https://github.com/gwangyi/pysetupdi ; "
             "platform_system=='Windows'"
         ),
         (


### PR DESCRIPTION
Fix #179 by removing the pysetupdi `#egg` part.

How to test:
```shell
$ deactivate
$ rm -rf ~/Downloads/env/bless/
$ python3 -m venv ~/Downloads/env/bless
$ source ~/Downloads/env/bless/bin/activate
$ pip install -e .
```

<details><summary>Full log:</summary>
<p>

```shell
Obtaining file:///home/user/Documents/bless
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Preparing editable metadata (pyproject.toml) ... done
Collecting bleak>=1.1.1 (from bless==0.3.0)
  Using cached bleak-2.1.1-py3-none-any.whl.metadata (5.2 kB)
Collecting coloredlogs (from bless==0.3.0)
  Using cached coloredlogs-15.0.1-py2.py3-none-any.whl.metadata (12 kB)
Collecting dbus_next (from bless==0.3.0)
  Using cached dbus_next-0.2.3-py3-none-any.whl.metadata (7.0 kB)
Collecting dbus-fast>=1.83.0 (from bleak>=1.1.1->bless==0.3.0)
  Using cached dbus_fast-4.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl.metadata (10 kB)
Collecting humanfriendly>=9.1 (from coloredlogs->bless==0.3.0)
  Using cached humanfriendly-10.0-py2.py3-none-any.whl.metadata (9.2 kB)
Using cached bleak-2.1.1-py3-none-any.whl (141 kB)
Using cached coloredlogs-15.0.1-py2.py3-none-any.whl (46 kB)
Using cached dbus_next-0.2.3-py3-none-any.whl (57 kB)
Using cached dbus_fast-4.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl (843 kB)
Using cached humanfriendly-10.0-py2.py3-none-any.whl (86 kB)
Building wheels for collected packages: bless
  Building editable for bless (pyproject.toml) ... done
  Created wheel for bless: filename=bless-0.3.0-0.editable-py3-none-any.whl size=4741 sha256=4af52a5cc5e60cc87cc0406a89647b94716f2cf9691c0bddadb13df003353920
  Stored in directory: /tmp/pip-ephem-wheel-cache-pcc9tj03/wheels/91/95/75/1bba1a90b93de367c0ec91db8ea1fad126f7cc1ac4a0379649
Successfully built bless
Installing collected packages: humanfriendly, dbus_next, dbus-fast, coloredlogs, bleak, bless
Successfully installed bleak-2.1.1 bless-0.3.0 coloredlogs-15.0.1 dbus-fast-4.0.0 dbus_next-0.2.3 humanfriendly-10.0
```

</p>
</details> 

<details><summary>Hardware tests have been run successfully</summary>
<p>

```shell
$ TEST_HARDWARE=True python -m pytest -s
======================================================== test session starts =========================================================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/user/Documents/bless
configfile: pytest.ini
plugins: asyncio-1.3.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collecting ... 2026-02-03 23:32:26 user asyncio[66437] DEBUG Using selector: EpollSelector
collected 16 items / 2 skipped                                                                                                       

test/backends/bluezdbus/test_application.py 2026-02-03 23:32:26 user asyncio[66437] DEBUG Using selector: EpollSelector

Please connect nowand subscribe to the characteristic 28d2f0f7-c5de-4759-b63d-d6d9dcac898e...
Press enter when ready...2026-02-03 23:32:34 user bless.backends.bluezdbus.dbus.characteristic[66437] DEBUG AcquireNotify on 28d2f0f7-c5de-4759-b63d-d6d9dcac898e from 46:90:E7:AE:91:77 on FD 13
2026-02-03 23:32:34 user bless.backends.bluezdbus.dbus.characteristic[66437] DEBUG Closing RX

Trigger a read and enter the hex value you see below
Value: FADEACE
Set the characteristic to the following: ACECAFE
Press enter when ready...
A new value will be sent
Press enter to receive the new value...
2026-02-03 23:33:08 user bless.backends.bluezdbus.dbus.characteristic[66437] DEBUG Sending update to 46:90:E7:AE:91:77
Enter the New value: BADCAFE
Unsubscribe from the characteristic
Press enter when ready...2026-02-03 23:33:18 user bless.backends.bluezdbus.dbus.characteristic[66437] DEBUG ReleaseNotify on 28d2f0f7-c5de-4759-b63d-d6d9dcac898e from 46:90:E7:AE:91:77

.
test/backends/bluezdbus/test_utils.py 2026-02-03 23:33:19 user asyncio[66437] DEBUG Using selector: EpollSelector
.
test/backends/test_server.py ss
test/backends/test_server_multiclient.py s
test/test_bleak_v1_compatibility.py 2026-02-03 23:33:19 user asyncio[66437] DEBUG Using selector: EpollSelector
.2026-02-03 23:33:19 user asyncio[66437] DEBUG Using selector: EpollSelector
.2026-02-03 23:33:19 user asyncio[66437] DEBUG Using selector: EpollSelector
2026-02-03 23:33:19 user bless.backends.characteristic[66437] DEBUG With on_read: None
.2026-02-03 23:33:19 user asyncio[66437] DEBUG Using selector: EpollSelector
2026-02-03 23:33:19 user bless.backends.characteristic[66437] DEBUG With on_read: None
.2026-02-03 23:33:19 user asyncio[66437] DEBUG Using selector: EpollSelector
.2026-02-03 23:33:19 user asyncio[66437] DEBUG Using selector: EpollSelector
2026-02-03 23:33:19 user bless.backends.characteristic[66437] DEBUG With on_read: None
.2026-02-03 23:33:19 user asyncio[66437] DEBUG Using selector: EpollSelector
2026-02-03 23:33:19 user bless.backends.characteristic[66437] DEBUG With on_read: None
.2026-02-03 23:33:19 user asyncio[66437] DEBUG Using selector: EpollSelector
2026-02-03 23:33:19 user bless.backends.characteristic[66437] DEBUG With on_read: None
..2026-02-03 23:33:19 user asyncio[66437] DEBUG Using selector: EpollSelector
2026-02-03 23:33:19 user bless.backends.characteristic[66437] DEBUG With on_read: None
2026-02-03 23:33:19 user bless.backends.characteristic[66437] DEBUG With on_read: None
.
test/test_init.py .

========================================================== warnings summary ==========================================================
../../Downloads/env/bless/lib/python3.12/site-packages/_pytest/config/__init__.py:1428
  /home/user/Downloads/env/bless/lib/python3.12/site-packages/_pytest/config/__init__.py:1428: PytestConfigWarning: Unknown config option: timeout
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

bless/backends/bluezdbus/dbus/session.py:28
  /home/user/Documents/bless/bless/backends/bluezdbus/dbus/session.py:28: DeprecationWarning: There is no current event loop
    loop: asyncio.AbstractEventLoop = asyncio.get_event_loop(),

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================= 13 passed, 5 skipped, 2 warnings in 52.44s =============================================
```

</p>
</details> 