### PR TITLE
Corrected typo "writable" in examples

### DIFF
--- a/examples/gattserver.py
+++ b/examples/gattserver.py
@@ -74,7 +74,7 @@ async def run(loop):
                 ),
                 "Permissions": (
                     GATTAttributePermissions.readable
-                    | GATTAttributePermissions.writable
+                    | GATTAttributePermissions.writeable
                 ),
                 "Value": None,
             }

--- a/examples/gattserver_notify.py
+++ b/examples/gattserver_notify.py
@@ -55,7 +55,7 @@ async def run(loop):
                 ),
                 "Permissions": (
                     GATTAttributePermissions.readable
-                    | GATTAttributePermissions.writable
+                    | GATTAttributePermissions.writeable
                 ),
                 "Value": None,
             }

--- a/examples/server.py
+++ b/examples/server.py
@@ -59,7 +59,7 @@ async def run(loop):
         | GATTCharacteristicProperties.write
         | GATTCharacteristicProperties.indicate
     )
-    permissions = GATTAttributePermissions.readable | GATTAttributePermissions.writable
+    permissions = GATTAttributePermissions.readable | GATTAttributePermissions.writeable
     await server.add_new_characteristic(
         my_service_uuid, my_char_uuid, char_flags, None, permissions
     )


### PR DESCRIPTION
I have modified "writable" in favor of "writeable" which is the one that exists